### PR TITLE
Update Dr. Ratio and implement rarity-based team sorting

### DIFF
--- a/src/data/characters/dpsCharacters.ts
+++ b/src/data/characters/dpsCharacters.ts
@@ -178,11 +178,12 @@ export const dpsCharacters: Character[] = [
     path: 'Hunt',
     rarity: 5,
     mainArchetype: 'DPS',
-    labels: ['DPS', 'Follow-up Attack', 'Debuff Synergy', 'F2P'],
+    labels: ['DPS', 'Sub-DPS', 'Follow-up Attack', 'Debuff Synergy', 'F2P'],
     teamRecommendations: {
-      requiresSubDPS: false,
-      amplifier: { bis: ['pela', 'silver-wolf'], generalist: ['bronya'], f2p: ['pela'] },
-      sustain: { bis: ['aventurine', 'fu-xuan'], generalist: ['huohuo'], f2p: ['gallagher'] },
+      requiresSubDPS: true,
+      subDPS: { bis: ['topaz'], generalist: [], f2p: ['moze'] },
+      amplifier: { bis: ['robin', 'cipher'], generalist: ['jiaoqiu', 'silver-wolf', 'tribbie', 'sunday'], f2p: ['pela', 'guinaifen'] },
+      sustain: { bis: ['aventurine'], generalist: ['huohuo', 'lingsha'], f2p: ['gallagher'] },
     },
   },
   {


### PR DESCRIPTION
- Add Dr. Ratio as dual main/sub-DPS with proper team recommendations
- Add BiS (Robin, Cipher, Topaz, Aventurine) and F2P (Pela, Guinaifen, Moze, Gallagher) options
- Implement rarity-based sorting for all team compositions (5-star > 4-star)
- Fix team ordering to prioritize higher rarity characters in recommended teams
- Ensure consistent character positioning across BiS, Generalist, and F2P team variants