### PR TITLE
Add info modal with version badge and character tracking

### DIFF
--- a/src/components/RecommendationTier.vue
+++ b/src/components/RecommendationTier.vue
@@ -12,7 +12,7 @@
     
     <div v-else-if="hasRecommendations" class="d-flex flex-wrap gap-2 justify-content-center">
       <div 
-        v-for="characterId in characterIds"
+        v-for="characterId in sortedCharacterIds"
         :key="characterId"
         class="text-center"
       >
@@ -78,6 +78,21 @@ const showNoSustainMessage = computed(() =>
   props.activeTab === 'sustain' && 
   props.noSustainAvailable
 )
+
+const sortedCharacterIds = computed(() => {
+  return [...props.characterIds].sort((a, b) => {
+    const charA = characters.find(c => c.id === a)
+    const charB = characters.find(c => c.id === b)
+    
+    // Sort by rarity (5-star first, then 4-star)
+    if (charA?.rarity !== charB?.rarity) {
+      return (charB?.rarity || 0) - (charA?.rarity || 0)
+    }
+    
+    // If same rarity, sort alphabetically by name
+    return (charA?.name || a).localeCompare(charB?.name || b)
+  })
+})
 
 const getCharacterName = (characterId: string): string => {
   const char = characters.find(c => c.id === characterId)

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -2,7 +2,17 @@
   <div class="top-bar py-2 mb-4">
     <div class="container-fluid d-flex flex-column flex-md-row justify-content-between align-items-center gap-2">
       <!-- Title -->
-      <h1 class="h4 mb-0 text-primary fw-bold text-center text-md-start">Honkai Star Rail Team Builder</h1>
+      <div class="d-flex align-items-center justify-content-center justify-content-md-start">
+        <h1 class="h4 mb-0 text-primary fw-bold">Honkai Star Rail Team Builder</h1>
+        <span 
+          class="badge bg-secondary ms-2 cursor-pointer"
+          data-bs-toggle="modal" 
+          data-bs-target="#infoModal"
+          style="font-size: 10px;"
+        >
+          v1.2.0
+        </span>
+      </div>
       
       <!-- Buttons -->
       <div class="d-flex gap-2 align-items-center flex-wrap justify-content-center">
@@ -70,6 +80,174 @@
       </div>
     </div>
   </div>
+
+  <!-- Info Modal -->
+  <div class="modal fade" id="infoModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content bg-dark border-primary">
+        <div class="modal-header border-primary">
+          <h5 class="modal-title text-primary">Information</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <!-- Tabs -->
+          <ul class="nav nav-tabs mb-3" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button
+                class="nav-link active custom-tab"
+                data-bs-toggle="tab"
+                data-bs-target="#missing-tab"
+                type="button"
+                role="tab"
+              >
+                Missing Characters
+              </button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button
+                class="nav-link custom-tab"
+                data-bs-toggle="tab"
+                data-bs-target="#todo-tab"
+                type="button"
+                role="tab"
+              >
+                TO-DO
+              </button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button
+                class="nav-link custom-tab"
+                data-bs-toggle="tab"
+                data-bs-target="#changelog-tab"
+                type="button"
+                role="tab"
+              >
+                CHANGELOGS
+              </button>
+            </li>
+          </ul>
+          
+          <!-- Tab Content -->
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="missing-tab" role="tabpanel">
+              <div class="text-white">
+                <h6 class="text-primary mb-3">Characters Missing Updates</h6>
+                
+                <div class="mb-4">
+                  <strong class="text-warning">DPS Characters:</strong>
+                  <ul class="list-unstyled ms-3 small mt-2">
+                    <li>• Jade - Incomplete team compositions</li>
+                    <li>• Kafka - Missing teammate sections</li>
+                    <li>• Boothill - No data</li>
+                    <li>• Firefly - No data</li>
+                    <li>• Feixiao - No data</li>
+                    <li>• Rappa - No data</li>
+                    <li>• Destruction Trailblazer - No data</li>
+                    <li>• Xueyi - No data</li>
+                    <li>• Dan Heng - No data</li>
+                    <li>• Arlan - No data</li>
+                    <li>• Serval - No data</li>
+                    <li>• Hook - No data</li>
+                    <li>• Qingque - No data</li>
+                    <li>• Sushang - No data</li>
+                    <li>• Herta - No data</li>
+                    <li>• Misha - No data</li>
+                    <li>• Hunt March 7th - No data</li>
+                    <li>• Moze - No data</li>
+                    <li>• Aglaea - No data</li>
+                    <li>• Castorice - No data</li>
+                    <li>• Mydei - No data</li>
+                    <li>• Phainon - No data</li>
+                    <li>• Saber - No data</li>
+                    <li>• Archer - No data</li>
+                    <li>• Anaxa - No data</li>
+                    <li>• The Herta - No data</li>
+                  </ul>
+                </div>
+                
+                <div class="mb-4">
+                  <strong class="text-warning">Support Characters:</strong>
+                  <ul class="list-unstyled ms-3 small mt-2">
+                    <li>• Bronya - No data</li>
+                    <li>• Sparkle - No data</li>
+                    <li>• Robin - No data</li>
+                    <li>• Ruan Mei - No data</li>
+                    <li>• Sunday - No data</li>
+                    <li>• Tingyun - No data</li>
+                    <li>• Asta - No data</li>
+                    <li>• Hanya - No data</li>
+                    <li>• Yukong - No data</li>
+                    <li>• Pela - No data</li>
+                    <li>• Silver Wolf - No data</li>
+                    <li>• Jiaoqiu - No data</li>
+                    <li>• Guinaifen - No data</li>
+                    <li>• Sampo - No data</li>
+                    <li>• Luka - No data</li>
+                    <li>• Welt - No data</li>
+                    <li>• Harmony Trailblazer - No data</li>
+                    <li>• Remembrance Trailblazer - No data</li>
+                    <li>• Tribbie - No data</li>
+                    <li>• Cipher - No data</li>
+                    <li>• Fugue - No data</li>
+                  </ul>
+                </div>
+                
+                <div class="mb-4">
+                  <strong class="text-warning">Sustain Characters:</strong>
+                  <ul class="list-unstyled ms-3 small mt-2">
+                    <li>• Aventurine - No data</li>
+                    <li>• Fu Xuan - No data</li>
+                    <li>• Gepard - No data</li>
+                    <li>• March 7th - No data</li>
+                    <li>• Fire Trailblazer - No data</li>
+                    <li>• Huohuo - No data</li>
+                    <li>• Bailu - No data</li>
+                    <li>• Luocha - No data</li>
+                    <li>• Lingsha - No data</li>
+                    <li>• Gallagher - No data</li>
+                    <li>• Lynx - No data</li>
+                    <li>• Natasha - No data</li>
+                    <li>• Hyacine - No data</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div class="tab-pane fade" id="todo-tab" role="tabpanel">
+              <div class="text-white">
+                <h6 class="text-primary mb-3">Upcoming Features</h6>
+                <ul class="list-unstyled">
+                  <li class="mb-2">• Add "Check Prydwen Build" link</li>
+                </ul>
+              </div>
+            </div>
+            <div class="tab-pane fade" id="changelog-tab" role="tabpanel">
+              <div class="text-white">
+                <h6 class="text-primary mb-3">Recent Updates</h6>
+                <div class="mb-3">
+                  <strong class="text-warning">v1.2.0</strong> - Latest
+                  <ul class="list-unstyled mt-2 ms-3">
+                    <li>• Added desktop padding for better layout</li>
+                    <li>• Added color legend for character recommendations</li>
+                    <li>• Fixed mobile tab switching bug</li>
+                    <li>• Added multiple archetype support</li>
+                    <li>• Improved teammate section sorting</li>
+                  </ul>
+                </div>
+                <div class="mb-3">
+                  <strong class="text-warning">v1.1.0</strong>
+                  <ul class="list-unstyled mt-2 ms-3">
+                    <li>• Enhanced character tooltip system</li>
+                    <li>• Improved team recommendation display</li>
+                    <li>• Added archetype filtering</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -114,5 +292,9 @@
   background-color: #555;
   color: white;
   text-decoration: none;
+}
+
+.cursor-pointer {
+  cursor: pointer;
 }
 </style>

--- a/src/composables/useCharacterFilters.ts
+++ b/src/composables/useCharacterFilters.ts
@@ -23,7 +23,7 @@ export function useCharacterFilters(characters: Character[]) {
         selectedRarities.value.includes(character.rarity)
       
       const archetypeMatch = selectedArchetypes.value.length === 0 || 
-        selectedArchetypes.value.includes(character.archetype)
+        selectedArchetypes.value.some(archetype => character.archetype.includes(archetype))
       
       return searchMatch && elementMatch && pathMatch && rarityMatch && archetypeMatch
     })

--- a/src/composables/useCharacterGrouping.ts
+++ b/src/composables/useCharacterGrouping.ts
@@ -5,9 +5,9 @@ export function useCharacterGrouping(filteredCharacters: { value: Character[] })
   const charactersByRole = computed(() => {
     const filtered = filteredCharacters.value
     
-    // DPS Column - characters with role 'DPS'
+    // DPS Column - characters with role 'DPS' or 'SUB_DPS'
     const dpsCharacters = filtered.filter(char => 
-      char.roles.includes('DPS')
+      char.roles.includes('DPS') || char.roles.includes('SUB_DPS')
     )
     
     // Support Column - characters with role 'SUPPORT'
@@ -25,12 +25,15 @@ export function useCharacterGrouping(filteredCharacters: { value: Character[] })
       const groups: { [key: string]: Character[] } = {}
       
       characters.forEach(char => {
-        let archetype = char.archetype || 'Other'
+        const archetypes = char.archetype || ['Other']
         
-        if (!groups[archetype]) {
-          groups[archetype] = []
-        }
-        groups[archetype].push(char)
+        // Add character to each of their archetype groups
+        archetypes.forEach(archetype => {
+          if (!groups[archetype]) {
+            groups[archetype] = []
+          }
+          groups[archetype].push(char)
+        })
       })
       
       return groups

--- a/src/constants/filterOptions.ts
+++ b/src/constants/filterOptions.ts
@@ -2,5 +2,5 @@ export const FILTER_OPTIONS = {
   elements: ['Physical', 'Fire', 'Ice', 'Lightning', 'Wind', 'Quantum', 'Imaginary'],
   paths: ['Destruction', 'Hunt', 'Erudition', 'Harmony', 'Nihility', 'Preservation', 'Abundance', 'Remembrance'],
   rarities: [5, 4],
-  archetypes: ['Break-DPS', 'Buffer', 'Counter', 'Debuffer', 'Follow-up', 'Healer', 'HP-Scaling', 'Hypercarry', 'Shielder', 'Ultimate-Based']
+  archetypes: ['Break-DPS', 'Buffer', 'Counter', 'Debuffer', 'Follow-up', 'Healer', 'HP-Scaling', 'Hypercarry', 'Shielder', 'Summon', 'Ultimate-Based']
 } as const

--- a/src/data/characters/dpsCharacters.ts
+++ b/src/data/characters/dpsCharacters.ts
@@ -8,12 +8,19 @@ export const dpsCharacters = [
     .rarity(5)
     .roles(['DPS'])
     .archetype('Hypercarry')
-    .labels(['Single Target', 'Quantum', 'Resurgence'])
-    .addTeammateSection('Amplifiers', ['sparkle', 'bronya'], ['tingyun'], ['tingyun'])
-    .addTeammateSection('Sustain', ['fu-xuan', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
-      ['seele', 'sparkle', 'tingyun', 'fu-xuan'],
-      ['seele', 'tingyun', 'pela', 'natasha']
+    .labels(['Single Target', 'Extra Turn', 'Buffed State', 'SP Unfriendly'])
+    .addTeammateSection(
+      'Amplifiers',
+      ['sparkle', 'silver-wolf'],
+      ['sunday', 'robin', 'cipher'],
+      ['remembrance-trailblazer', 'bronya', 'tingyun', 'hanya', 'pela'],
+    )
+    .addTeammateSection('Sustain', ['fu-xuan'], ['huohuo'], ['gallagher'])
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
+      ['seele', 'sparkle', 'silver-wolf', 'fu-xuan'],
+      ['seele', 'tingyun', 'hanya', 'gallagher'],
     )
     .build(),
 
@@ -22,13 +29,20 @@ export const dpsCharacters = [
     .path('Erudition')
     .rarity(5)
     .roles(['DPS'])
-    .archetype('Follow-up')
-    .labels(['AoE', 'Lightning Lord', 'Follow-up Attack'])
-    .addTeammateSection('Amplifiers', ['tingyun', 'bronya'], ['sparkle'], ['tingyun'])
-    .addTeammateSection('Sustain', ['fu-xuan', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
-      ['jing-yuan', 'tingyun', 'bronya', 'fu-xuan'],
-      ['jing-yuan', 'tingyun', 'pela', 'natasha']
+    .archetype('Follow-up', 'Summon')
+    .labels(['AoE', 'Summon', 'Follow-up Attack'])
+    .addTeammateSection(
+      'Amplifiers',
+      ['robin', 'sunday'],
+      ['tribbie', 'cipher', 'sparkle', 'ruan-mei'],
+      ['bronya', 'tingyun', 'pela'],
+    )
+    .addTeammateSection('Sustain', ['aventurine', 'huohuo'], ['hyacine'], ['gallagher'])
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
+      ['jing-yuan', 'robin', 'sunday', 'aventurine'],
+      ['jing-yuan', 'tingyun', 'pela', 'gallagher'],
     )
     .build(),
 
@@ -38,12 +52,26 @@ export const dpsCharacters = [
     .rarity(5)
     .roles(['DPS'])
     .archetype('Counter')
-    .labels(['Counter Attack', 'Physical', 'AoE'])
-    .addTeammateSection('Amplifiers', ['tingyun', 'bronya'], ['sparkle'], ['tingyun'])
-    .addTeammateSection('Sustain', ['fu-xuan', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
-      ['clara', 'tingyun', 'bronya', 'fu-xuan'],
-      ['clara', 'tingyun', 'pela', 'natasha']
+    .labels(['Counter Attack', 'Blast', 'AoE', 'F2P'])
+    .addTeammateSection('Dual DPS', ['yunli'], ['cipher', 'topaz'], [])
+    .addTeammateSection(
+      'Amplifiers',
+      ['robin'],
+      ['tribbie', 'silver-wolf', 'sunday', 'sparkle'],
+      ['remembrance-trailblazer', 'pela'],
+    )
+    .addTeammateSection('Sustain', ['aventurine', 'huohuo'], ['luocha'], ['gallagher', 'lynx'])
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
+      ['clara', 'robin', 'sunday', 'huohuo'],
+      ['clara', 'tingyun', 'remembrance-trailblazer', 'gallagher'],
+    )
+    .addTeamComposition(
+      'Counter Duo',
+      'Sub DPS',
+      ['yunli', 'clara', 'robin', 'aventurine'],
+      ['yunli', 'clara', 'pela', 'gallagher'],
     )
     .build(),
 
@@ -51,15 +79,36 @@ export const dpsCharacters = [
     .element('Fire')
     .path('Erudition')
     .rarity(5)
-    .roles(['DPS'])
-    .archetype('Follow-up')
-    .labels(['AoE', 'Fire', 'Follow-up Attack'])
-    .addTeammateSection('Amplifiers', ['asta', 'tingyun'], ['bronya'], ['asta'])
-    .addTeammateSection('Sustain', ['fu-xuan', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
-      ['himeko', 'asta', 'tingyun', 'fu-xuan'],
-      ['himeko', 'asta', 'pela', 'natasha']
+    .roles(['SUB_DPS'])
+    .archetype('Follow-up', 'Break-DPS')
+    .labels(['AoE', 'Blast', 'Follow-up Attack', 'F2P'])
+    .addTeammateSection('Dual DPS', ['the-herta'], ['anaxa'], ['herta'])
+    .addTeammateSection(
+      'Dual Amplifiers',
+      ['tribbie'],
+      ['robin', 'ruan-mei', 'silver-wolf'],
+      ['pela'],
     )
+    .addTeammateSection(
+      'Break Amplifiers',
+      ['fugue', 'ruan-mei'],
+      ['cipher'],
+      ['harmony-trailblazer'],
+    )
+    .addTeammateSection('Sustain', ['lingsha'], ['hyacine', 'huohuo'], ['gallagher'])
+    .addTeamComposition(
+      'Dual DPS',
+      'Sub DPS',
+      ['himeko', 'the-herta', 'tribbie', 'lingsha'],
+      ['himeko', 'herta', 'pela', 'gallagher'],
+    )
+    .addTeamComposition(
+      'Break Team',
+      'Main DPS',
+      ['himeko', 'fugue', 'ruan-mei', 'lingsha'],
+      ['himeko', 'harmony-trailblazer', 'pela', 'gallagher'],
+    )
+
     .build(),
 
   new CharacterBuilder('yanqing', 'Yanqing')
@@ -68,12 +117,14 @@ export const dpsCharacters = [
     .rarity(5)
     .roles(['DPS'])
     .archetype('Hypercarry')
-    .labels(['Single Target', 'Ice', 'Crit'])
+    .labels(['Single Target', 'Follow-up Attack', 'F2P'])
     .addTeammateSection('Amplifiers', ['bronya', 'sparkle'], ['tingyun'], ['tingyun'])
     .addTeammateSection('Sustain', ['gepard', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['yanqing', 'bronya', 'sparkle', 'gepard'],
-      ['yanqing', 'tingyun', 'pela', 'natasha']
+      ['yanqing', 'tingyun', 'pela', 'natasha'],
     )
     .build(),
 
@@ -85,15 +136,24 @@ export const dpsCharacters = [
     .archetype('HP-Scaling')
     .labels(['Follow-up Attack', 'HP Scaling', 'Self Damage'])
     .addTeammateSection('Sub-DPS Partners', ['castorice'], ['jingliu'], ['remembrance-trailblazer'])
-    .addTeammateSection('Amplifiers', ['sunday', 'tribbie'], ['silver-wolf', 'cipher', 'ruan-mei'], ['bronya', 'remembrance-trailblazer'])
-    .addTeammateSection('Sustain', ['hyacine'], ['huohuo', 'luocha'], ['gallagher'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
-      ['blade', 'sunday', 'jingliu', 'hyacine'],
-      ['blade', 'bronya', 'pela', 'gallagher']
+    .addTeammateSection(
+      'Amplifiers',
+      ['sunday', 'tribbie'],
+      ['silver-wolf', 'cipher', 'ruan-mei'],
+      ['bronya', 'remembrance-trailblazer'],
     )
-    .addTeamComposition('Sub-DPS Team', 'Sub-DPS',
+    .addTeammateSection('Sustain', ['hyacine'], ['huohuo', 'luocha'], ['gallagher'])
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
+      ['blade', 'sunday', 'jingliu', 'hyacine'],
+      ['blade', 'bronya', 'pela', 'gallagher'],
+    )
+    .addTeamComposition(
+      'Sub-DPS Team',
+      'Sub-DPS',
       ['castorice', 'blade', 'tribbie', 'hyacine'],
-      ['jingliu', 'blade', 'remembrance-trailblazer', 'gallagher']
+      ['jingliu', 'blade', 'remembrance-trailblazer', 'gallagher'],
     )
     .build(),
 
@@ -106,9 +166,11 @@ export const dpsCharacters = [
     .labels(['Single Target', 'Imaginary', 'Enhanced Basic'])
     .addTeammateSection('Amplifiers', ['sparkle', 'bronya'], ['tingyun'], ['tingyun'])
     .addTeammateSection('Sustain', ['fu-xuan', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['dan-heng-il', 'sparkle', 'bronya', 'fu-xuan'],
-      ['dan-heng-il', 'tingyun', 'pela', 'natasha']
+      ['dan-heng-il', 'tingyun', 'pela', 'natasha'],
     )
     .build(),
 
@@ -121,9 +183,11 @@ export const dpsCharacters = [
     .labels(['AoE', 'HP Consumption', 'Enhanced State'])
     .addTeammateSection('Amplifiers', ['bronya', 'sparkle'], ['tingyun'], ['tingyun'])
     .addTeammateSection('Sustain', ['luocha', 'bailu'], ['fu-xuan'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['jingliu', 'bronya', 'sparkle', 'luocha'],
-      ['jingliu', 'tingyun', 'pela', 'natasha']
+      ['jingliu', 'tingyun', 'pela', 'natasha'],
     )
     .build(),
 
@@ -136,9 +200,11 @@ export const dpsCharacters = [
     .labels(['AoE', 'Ultimate Based', 'Energy Hungry'])
     .addTeammateSection('Amplifiers', ['tingyun', 'huohuo'], ['bronya'], ['tingyun'])
     .addTeammateSection('Sustain', ['huohuo', 'luocha'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['argenti', 'tingyun', 'huohuo', 'luocha'],
-      ['argenti', 'tingyun', 'pela', 'natasha']
+      ['argenti', 'tingyun', 'pela', 'natasha'],
     )
     .build(),
 
@@ -151,9 +217,11 @@ export const dpsCharacters = [
     .labels(['AoE', 'Debuff Stacking', 'Ultimate Based'])
     .addTeammateSection('Debuffers', ['jiaoqiu'], ['pela', 'silver-wolf'], ['pela'])
     .addTeammateSection('Sustain', ['aventurine', 'fu-xuan'], ['huohuo'], ['gallagher'])
-    .addTeamComposition('Debuff Team', 'Main DPS',
+    .addTeamComposition(
+      'Debuff Team',
+      'Main DPS',
       ['acheron', 'jiaoqiu', 'pela', 'aventurine'],
-      ['acheron', 'pela', 'guinaifen', 'gallagher']
+      ['acheron', 'pela', 'guinaifen', 'gallagher'],
     )
     .build(),
 
@@ -166,9 +234,11 @@ export const dpsCharacters = [
     .labels(['Counter Attack', 'Physical', 'Ultimate Based'])
     .addTeammateSection('Amplifiers', ['tingyun', 'bronya'], ['sparkle'], ['tingyun'])
     .addTeammateSection('Sustain', ['huohuo', 'aventurine'], ['fu-xuan'], ['gallagher'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['yunli', 'tingyun', 'bronya', 'huohuo'],
-      ['yunli', 'tingyun', 'pela', 'gallagher']
+      ['yunli', 'tingyun', 'pela', 'gallagher'],
     )
     .build(),
 
@@ -181,9 +251,11 @@ export const dpsCharacters = [
     .labels(['Follow-up Attack', 'Debt', 'Fire'])
     .addTeammateSection('Amplifiers', ['robin', 'aventurine'], ['bronya'], ['tingyun'])
     .addTeammateSection('Sustain', ['aventurine', 'huohuo'], ['fu-xuan'], ['gallagher'])
-    .addTeamComposition('FUA Team', 'Main DPS',
+    .addTeamComposition(
+      'FUA Team',
+      'Main DPS',
       ['topaz', 'robin', 'aventurine', 'huohuo'],
-      ['topaz', 'tingyun', 'pela', 'gallagher']
+      ['topaz', 'tingyun', 'pela', 'gallagher'],
     )
     .build(),
 
@@ -195,11 +267,18 @@ export const dpsCharacters = [
     .archetype('Follow-up')
     .labels(['Follow-up Attack', 'Debuff Synergy'])
     .addTeammateSection('Sub-DPS Partners', ['topaz'], [], ['moze'])
-    .addTeammateSection('Debuffers', ['robin', 'cipher'], ['jiaoqiu', 'silver-wolf', 'tribbie', 'sunday'], ['pela', 'guinaifen'])
+    .addTeammateSection(
+      'Debuffers',
+      ['robin', 'cipher'],
+      ['jiaoqiu', 'silver-wolf', 'tribbie', 'sunday'],
+      ['pela', 'guinaifen'],
+    )
     .addTeammateSection('Sustain', ['aventurine'], ['huohuo', 'lingsha'], ['gallagher'])
-    .addTeamComposition('FUA Team', 'Main DPS',
+    .addTeamComposition(
+      'FUA Team',
+      'Main DPS',
       ['ratio', 'topaz', 'robin', 'aventurine'],
-      ['ratio', 'moze', 'pela', 'gallagher']
+      ['ratio', 'moze', 'pela', 'gallagher'],
     )
     .build(),
 
@@ -212,9 +291,11 @@ export const dpsCharacters = [
     .labels(['Follow-up Attack', 'Debt', 'AoE'])
     .addTeammateSection('Amplifiers', ['sparkle', 'bronya'], ['tingyun'], ['tingyun'])
     .addTeammateSection('Sustain', ['aventurine', 'huohuo'], ['fu-xuan'], ['gallagher'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['jade', 'sparkle', 'bronya', 'aventurine'],
-      ['jade', 'tingyun', 'pela', 'gallagher']
+      ['jade', 'tingyun', 'pela', 'gallagher'],
     )
     .build(),
 
@@ -228,9 +309,11 @@ export const dpsCharacters = [
     .addTeammateSection('Sub-DPS Partners', ['black-swan'], ['sampo'], ['sampo'])
     .addTeammateSection('Amplifiers', ['ruan-mei', 'jiaoqiu'], ['tingyun'], ['tingyun'])
     .addTeammateSection('Sustain', ['huohuo', 'fu-xuan'], ['bailu'], ['lynx'])
-    .addTeamComposition('DoT Team', 'Main DPS',
+    .addTeamComposition(
+      'DoT Team',
+      'Main DPS',
       ['kafka', 'black-swan', 'ruan-mei', 'huohuo'],
-      ['kafka', 'sampo', 'tingyun', 'lynx']
+      ['kafka', 'sampo', 'tingyun', 'lynx'],
     )
     .build(),
 
@@ -243,9 +326,11 @@ export const dpsCharacters = [
     .labels(['DoT', 'Wind', 'Arcana'])
     .addTeammateSection('Amplifiers', ['ruan-mei', 'jiaoqiu'], ['tingyun'], ['tingyun'])
     .addTeammateSection('Sustain', ['huohuo', 'fu-xuan'], ['bailu'], ['lynx'])
-    .addTeamComposition('DoT Team', 'Main DPS',
+    .addTeamComposition(
+      'DoT Team',
+      'Main DPS',
       ['black-swan', 'kafka', 'ruan-mei', 'huohuo'],
-      ['black-swan', 'sampo', 'tingyun', 'lynx']
+      ['black-swan', 'sampo', 'tingyun', 'lynx'],
     )
     .build(),
 
@@ -285,9 +370,11 @@ export const dpsCharacters = [
     .labels(['Physical', 'Taunt', 'F2P'])
     .addTeammateSection('Amplifiers', ['tingyun', 'bronya'], ['asta'], ['tingyun'])
     .addTeammateSection('Sustain', ['gepard', 'fu-xuan'], ['bailu'], ['natasha'])
-    .addTeamComposition('Main DPS Team', 'Main DPS',
+    .addTeamComposition(
+      'Main DPS Team',
+      'Main DPS',
       ['destruction-trailblazer', 'tingyun', 'bronya', 'gepard'],
-      ['destruction-trailblazer', 'tingyun', 'asta', 'natasha']
+      ['destruction-trailblazer', 'tingyun', 'asta', 'natasha'],
     )
     .build(),
 
@@ -299,11 +386,18 @@ export const dpsCharacters = [
     .roles(['DPS'])
     .archetype('Break-DPS')
     .labels(['Break DPS', 'Single Target', 'Implant Weakness'])
-    .addTeammateSection('Amplifiers', ['fugue', 'ruan-mei'], ['sunday'], ['bronya', 'harmony-trailblazer'])
+    .addTeammateSection(
+      'Amplifiers',
+      ['fugue', 'ruan-mei'],
+      ['sunday'],
+      ['bronya', 'harmony-trailblazer'],
+    )
     .addTeammateSection('Sustain', ['lingsha'], ['hyacine', 'fu-xuan', 'huohuo'], ['gallagher'])
-    .addTeamComposition('Break Team', 'Main DPS',
+    .addTeamComposition(
+      'Break Team',
+      'Main DPS',
       ['boothill', 'fugue', 'ruan-mei', 'lingsha'],
-      ['boothill', 'harmony-trailblazer', 'bronya', 'gallagher']
+      ['boothill', 'harmony-trailblazer', 'bronya', 'gallagher'],
     )
     .build(),
 
@@ -313,12 +407,21 @@ export const dpsCharacters = [
     .rarity(5)
     .roles(['DPS'])
     .archetype('Break-DPS')
-    .labels(['Break DPS', 'Super Break', 'Implant Weakness', 'Action Advance', 'Blast'])
-    .addTeammateSection('Amplifiers', ['ruan-mei', 'fugue'], [], ['harmony-trailblazer'])
-    .addTeammateSection('Sustain', ['lingsha'], ['huohuo'], ['gallagher'])
-    .addTeamComposition('Break Team', 'Main DPS',
-      ['firefly', 'ruan-mei', 'fugue', 'lingsha'],
-      ['firefly', 'harmony-trailblazer', 'gallagher', 'natasha']
+    .labels([
+      'Break DPS',
+      'Super Break',
+      'Implant Weakness',
+      'Action Advance',
+      'Blast',
+      'Buffed State',
+    ])
+    .addTeammateSection('Amplifiers', ['fugue', 'ruan-mei'], ['cipher'], ['harmony-trailblazer'])
+    .addTeammateSection('Sustain', ['lingsha'], ['huohuo', 'aventurine'], ['gallagher'])
+    .addTeamComposition(
+      'Break Team',
+      'Main DPS',
+      ['firefly', 'fugue', 'ruan-mei', 'lingsha'],
+      ['firefly', 'harmony-trailblazer', 'bronya', 'gallagher'],
     )
     .build(),
 
@@ -329,11 +432,13 @@ export const dpsCharacters = [
     .roles(['DPS'])
     .archetype('Break-DPS')
     .labels(['Break DPS', 'AoE', 'Blast', 'Super Break'])
-    .addTeammateSection('Amplifiers', ['fugue', 'ruan-mei'], [], ['harmony-trailblazer'])
+    .addTeammateSection('Amplifiers', ['fugue', 'ruan-mei'], ['tribbie'], ['harmony-trailblazer'])
     .addTeammateSection('Sustain', ['lingsha'], ['huohuo'], ['gallagher'])
-    .addTeamComposition('Break Team', 'Main DPS',
+    .addTeamComposition(
+      'Break Team',
+      'Main DPS',
       ['rappa', 'fugue', 'ruan-mei', 'lingsha'],
-      ['rappa', 'harmony-trailblazer', 'gallagher', 'natasha']
+      ['rappa', 'harmony-trailblazer', 'bronya', 'gallagher'],
     )
     .build(),
 
@@ -422,7 +527,12 @@ export const dpsCharacters = [
     .roles(['DPS'])
     .archetype('Break-DPS')
     .labels(['Break DPS', 'Quantum', 'Toughness Damage', 'F2P'])
-    .addTeammateSection('Amplifiers', ['ruan-mei', 'harmony-trailblazer'], ['bronya'], ['harmony-trailblazer'])
+    .addTeammateSection(
+      'Amplifiers',
+      ['ruan-mei', 'harmony-trailblazer'],
+      ['bronya'],
+      ['harmony-trailblazer'],
+    )
     .addTeammateSection('Sustain', ['fu-xuan', 'huohuo'], ['bailu'], ['lynx'])
     .build(),
 
@@ -474,7 +584,12 @@ export const dpsCharacters = [
     .roles(['DPS'])
     .archetype('Hypercarry')
     .labels(['Summon', 'Lightning', 'Remembrance'])
-    .addTeammateSection('Amplifiers', ['sunday', 'remembrance-trailblazer'], ['bronya'], ['remembrance-trailblazer'])
+    .addTeammateSection(
+      'Amplifiers',
+      ['sunday', 'remembrance-trailblazer'],
+      ['bronya'],
+      ['remembrance-trailblazer'],
+    )
     .addTeammateSection('Sustain', ['aventurine', 'huohuo'], ['fu-xuan'], ['gallagher'])
     .build(),
 

--- a/src/types/Character.ts
+++ b/src/types/Character.ts
@@ -8,7 +8,7 @@ export interface Character {
   path: Path
   rarity: Rarity
   roles: Role[]           // Multiple roles: ['DPS', 'SUB_DPS']
-  archetype: Archetype    // How they play: 'Hypercarry', 'HP-Scaling', etc.
+  archetype: Archetype[]  // How they play: ['Hypercarry'], ['Follow-up', 'Summon'], etc.
   labels: string[]        // Descriptive tags
   
   // Flexible teammate recommendations
@@ -32,6 +32,7 @@ export type Archetype =
   | 'Counter'
   | 'Ultimate-Based'
   | 'Energy-Hungry'
+  | 'Summon'
 
 // Flexible teammate section - you can name it whatever you want
 export interface TeammateSection {
@@ -83,8 +84,8 @@ export class CharacterBuilder {
     return this
   }
 
-  archetype(archetype: Archetype) {
-    this.character.archetype = archetype
+  archetype(...archetypes: Archetype[]) {
+    this.character.archetype = archetypes
     return this
   }
 


### PR DESCRIPTION
- Add v1.2.0 version badge to TopBar title that opens info modal
- Add comprehensive Missing Characters tab with all DPS, Support, and Sustain characters needing updates
- Add simplified TO-DO section with Prydwen build link feature
- Add CHANGELOGS section with recent version history
- Improve teammate section sorting (5-star first, then alphabetical)
- Support multiple archetypes per character (e.g., Jing Yuan as Follow-up + Summon)