### PR TITLE
fix: resolve Satania gif not showing for characters with empty team data

### DIFF
--- a/packages/frontend/src/components/TeamRecommendations.vue
+++ b/packages/frontend/src/components/TeamRecommendations.vue
@@ -193,17 +193,7 @@ const currentTeamComposition = computed(() =>
 const hasNoTeamData = computed(() => {
   const hasNoTeammates = !props.character.teammateRecommendations || props.character.teammateRecommendations.length === 0
   const hasNoCompositions = !props.character.teamCompositions || props.character.teamCompositions.length === 0
-  const result = hasNoTeammates && hasNoCompositions
-  
-  // Debug logging
-  console.log('Character:', props.character.name)
-  console.log('teammateRecommendations:', props.character.teammateRecommendations)
-  console.log('teamCompositions:', props.character.teamCompositions)
-  console.log('hasNoTeammates:', hasNoTeammates)
-  console.log('hasNoCompositions:', hasNoCompositions)
-  console.log('hasNoTeamData result:', result)
-  
-  return result
+  return hasNoTeammates && hasNoCompositions
 })
 
 const { hoveredCharacter, tooltipPosition, showTooltip, hideTooltip } = useTooltip()

--- a/packages/frontend/src/views/HomeView.vue
+++ b/packages/frontend/src/views/HomeView.vue
@@ -59,7 +59,8 @@ const getNewFormatCharacter = (characterId: string) => {
 // Check if selected character has full API data (not just static data)
 const hasFullCharacterData = (characterId: string) => {
   const character = characters.value.find((char) => char.id === characterId)
-  return character && character.teammateRecommendations && character.teammateRecommendations.length > 0
+  // Character has full data if it has the teammateRecommendations property (even if empty array)
+  return character && character.hasOwnProperty('teammateRecommendations')
 }
 </script>
 


### PR DESCRIPTION
Root cause: hasFullCharacterData function incorrectly required teammateRecommendations.length > 0 This caused characters with empty arrays to get stuck in loading state instead of rendering TeamRecommendations component

Solution:
- Changed hasFullCharacterData to check for property existence instead of array length
- Characters with empty teammateRecommendations/teamCompositions now properly render TeamRecommendations
- hasNoTeamData computed property correctly identifies empty arrays and shows Satania gif

Tested with Dan Heng PT character who has empty arrays - now properly shows 'no data' message with gif