### PR TITLE
[codex] Refresh frontend data after backend wakes

### DIFF
--- a/packages/frontend/src/composables/useCharactersApi.ts
+++ b/packages/frontend/src/composables/useCharactersApi.ts
@@ -7,13 +7,29 @@ import { staticCharacterList } from '../data/staticCharacters'
 const characters = ref<Character[]>(staticCharacterList)
 const loading = ref(false)
 const error = ref<string | null>(null)
+const RETRY_DELAY_MS = 10000
+
+let retryTimer: ReturnType<typeof setTimeout> | null = null
+
+const hasApiCharacterData = (character: Character | undefined) =>
+  Boolean(character && 'teammateRecommendations' in character)
+
+const hasLoadedApiCharacters = () =>
+  characters.value.length > 0 && hasApiCharacterData(characters.value[0])
+
+const clearRetryTimer = () => {
+  if (retryTimer) {
+    clearTimeout(retryTimer)
+    retryTimer = null
+  }
+}
 
 // Load characters from API
 export const useCharactersApi = () => {
   const loadCharacters = async () => {
     // Check if we already have API data (not just static data)
-    if (characters.value.length > 0 && characters.value[0]?.teammateRecommendations?.length > 0) {
-      return // Already loaded API data
+    if (hasLoadedApiCharacters() || loading.value) {
+      return
     }
 
     loading.value = true
@@ -21,11 +37,19 @@ export const useCharactersApi = () => {
 
     try {
       const apiCharacters = await CharacterService.getAllCharacters()
-      characters.value = apiCharacters // Replace static data with API data
+      characters.value = apiCharacters
+      clearRetryTimer()
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load characters'
       console.error('Failed to load characters:', err)
-      // Keep static characters if API fails
+      // Keep static characters if API fails, but retry so the UI can recover
+      // when the backend wakes up.
+      if (!retryTimer) {
+        retryTimer = setTimeout(() => {
+          retryTimer = null
+          void loadCharacters()
+        }, RETRY_DELAY_MS)
+      }
     } finally {
       loading.value = false
     }

--- a/packages/frontend/src/composables/useHomeView.ts
+++ b/packages/frontend/src/composables/useHomeView.ts
@@ -2,7 +2,7 @@ import { useCharacterFilters } from './useCharacterFilters'
 import { useCharacterGrouping } from './useCharacterGrouping'
 import { useCharacterSelection } from './useCharacterSelection'
 import { useSearch } from './useSearch'
-import { type ComputedRef } from 'vue'
+import { type ComputedRef, watch } from 'vue'
 import type { Character } from '@hsr-team-builder/shared'
 
 export function useHomeView(characters: ComputedRef<Character[]>) {
@@ -51,6 +51,18 @@ export function useHomeView(characters: ComputedRef<Character[]>) {
     searchQueryRef.value = ''
     clearSelection()
   }
+
+  watch(characters, (nextCharacters) => {
+    const currentSelection = selectedCharacter.value
+    if (!currentSelection) {
+      return
+    }
+
+    const refreshedCharacter = nextCharacters.find((char) => char.id === currentSelection.id)
+    if (refreshedCharacter && refreshedCharacter !== currentSelection) {
+      selectedCharacter.value = refreshedCharacter
+    }
+  })
 
   const getActiveTab = () => {
     // If a character is selected, switch to their role's tab

--- a/packages/frontend/src/composables/useVersionInfo.ts
+++ b/packages/frontend/src/composables/useVersionInfo.ts
@@ -20,11 +20,33 @@ export function useVersionInfo() {
   const isLoadingRoadmap = ref(false)
   const error = ref<string | null>(null)
   const roadmapError = ref<string | null>(null)
+  const RETRY_DELAY_MS = 10000
+
+  let versionRetryTimer: ReturnType<typeof setTimeout> | null = null
+  let roadmapRetryTimer: ReturnType<typeof setTimeout> | null = null
 
   // Get current app version from environment
   const appVersion = computed(() => import.meta.env.VITE_APP_VERSION || 'v2.6.2')
 
+  const clearVersionRetryTimer = () => {
+    if (versionRetryTimer) {
+      clearTimeout(versionRetryTimer)
+      versionRetryTimer = null
+    }
+  }
+
+  const clearRoadmapRetryTimer = () => {
+    if (roadmapRetryTimer) {
+      clearTimeout(roadmapRetryTimer)
+      roadmapRetryTimer = null
+    }
+  }
+
   const fetchVersionInfo = async () => {
+    if (isLoading.value) {
+      return
+    }
+
     isLoading.value = true
     error.value = null
 
@@ -38,6 +60,7 @@ export function useVersionInfo() {
 
       const data = await response.json()
       currentVersionInfo.value = data
+      clearVersionRetryTimer()
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load version information'
       console.warn('Version info API unavailable, using fallback content')
@@ -59,12 +82,23 @@ export function useVersionInfo() {
           'Mobile layout properly activates at correct breakpoints',
         ],
       }
+
+      if (!versionRetryTimer) {
+        versionRetryTimer = setTimeout(() => {
+          versionRetryTimer = null
+          void fetchVersionInfo()
+        }, RETRY_DELAY_MS)
+      }
     } finally {
       isLoading.value = false
     }
   }
 
   const fetchRoadmap = async () => {
+    if (isLoadingRoadmap.value) {
+      return
+    }
+
     isLoadingRoadmap.value = true
     roadmapError.value = null
 
@@ -77,6 +111,7 @@ export function useVersionInfo() {
 
       const data = await response.json()
       roadmapItems.value = Array.isArray(data) ? data : []
+      clearRoadmapRetryTimer()
     } catch (err) {
       roadmapError.value = err instanceof Error ? err.message : 'Failed to load roadmap'
       console.warn('Roadmap API unavailable, using fallback content')
@@ -85,6 +120,13 @@ export function useVersionInfo() {
       roadmapItems.value = [
         'Allow users to pick their owned characters, store locally, and recommend teams based on their roster',
       ]
+
+      if (!roadmapRetryTimer) {
+        roadmapRetryTimer = setTimeout(() => {
+          roadmapRetryTimer = null
+          void fetchRoadmap()
+        }, RETRY_DELAY_MS)
+      }
     } finally {
       isLoadingRoadmap.value = false
     }


### PR DESCRIPTION
## What changed
This PR fixes the frontend behavior when the backend is asleep on Railway and the app starts in local fallback mode.

Instead of staying on stale local data until a full page refresh, the frontend now retries in the background and updates itself when the backend becomes available again.

## Why it changed
The current behavior was:
- first request fails while the backend is sleeping
- frontend falls back to local/static data
- page stays stuck on that fallback data for the rest of the session
- only a manual browser refresh loads the fresh backend data

That regression made the app look outdated even after the backend had already woken up.

## Impact
Frontend changes only:
- adds background retry logic for character API loading
- adds background retry logic for version info and roadmap loading
- remaps the currently selected character to the refreshed API object so the UI updates without a full page reload
- avoids duplicate retry spam while requests are already in flight

Files changed:
- `packages/frontend/src/composables/useCharactersApi.ts`
- `packages/frontend/src/composables/useVersionInfo.ts`
- `packages/frontend/src/composables/useHomeView.ts`

## Validation
- `npm run build -w @hsr-team-builder/frontend`

## Notes
This is frontend behavior work. If you want this fix deployed to production after merge, it should follow your normal frontend tag-triggered deploy flow.