### PR TITLE
[codex] fix swagger mismatches and add bulk character updates

### DIFF
--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
 import { getAdminPassword, getAdminUsername } from '../config/env'
 
@@ -35,7 +35,7 @@ export class AuthService {
   async login(username: string, password: string) {
     const user = await this.validateAdmin(username, password)
     if (!user) {
-      throw new Error('Invalid credentials')
+      throw new UnauthorizedException('Invalid credentials')
     }
 
     const payload: JwtPayload = {

--- a/packages/backend/src/characters/characters.controller.ts
+++ b/packages/backend/src/characters/characters.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpException,
   HttpStatus,
   Param,
+  Patch,
   Post,
   Put,
   Query,
@@ -14,20 +15,28 @@ import {
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiExtraModels,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
+  getSchemaPath,
 } from '@nestjs/swagger'
 import { CharactersService } from './characters.service'
 import { Character, Role } from '../types/Character'
-import { CreateCharacterDto, UpdateCharacterDto } from '../dto/character.dto'
+import {
+  BulkCharacterUpdateDto,
+  BulkCharacterUpdateResponseDto,
+  CreateCharacterDto,
+  UpdateCharacterDto,
+} from '../dto/character.dto'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 
 const ROLE_VALUES: Role[] = ['DPS', 'SUB_DPS', 'SUPPORT', 'SUSTAIN', 'AMPLIFIER']
 const isRole = (value: string): value is Role => ROLE_VALUES.includes(value as Role)
 
+@ApiExtraModels(CreateCharacterDto, BulkCharacterUpdateResponseDto)
 @ApiTags('characters')
 @Controller('characters')
 export class CharactersController {
@@ -68,35 +77,7 @@ export class CharactersController {
     schema: {
       type: 'array',
       items: {
-        type: 'object',
-        properties: {
-          id: { type: 'string', example: 'kafka' },
-          name: { type: 'string', example: 'Kafka' },
-          element: { type: 'string', example: 'Lightning' },
-          path: { type: 'string', example: 'Nihility' },
-          rarity: { type: 'number', example: 5 },
-          roles: { type: 'array', items: { type: 'string' }, example: ['DPS'] },
-          archetype: { type: 'array', items: { type: 'string' }, example: ['DoT'] },
-          labels: { type: 'array', items: { type: 'string' }, example: ['DoT', 'AoE'] },
-          prydwenLink: {
-            type: 'string',
-            example: 'https://www.prydwen.gg/star-rail/characters/kafka/',
-          },
-          guobaLink: { type: 'string', example: 'https://www.youtube.com/embed/xyz123' },
-          lightcones: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', example: 'in-the-name-of-the-world' },
-                name: { type: 'string', example: 'In the Name of the World' },
-                rarity: { type: 'number', example: 5 },
-                path: { type: 'string', example: 'Nihility' },
-                note: { type: 'string', example: 'Best in slot vs. imaginary weak enemies' },
-              },
-            },
-          },
-        },
+        $ref: getSchemaPath(CreateCharacterDto),
       },
     },
   })
@@ -142,35 +123,7 @@ export class CharactersController {
     status: 200,
     description: 'Character details with associated lightcones',
     schema: {
-      type: 'object',
-      properties: {
-        id: { type: 'string', example: 'kafka' },
-        name: { type: 'string', example: 'Kafka' },
-        element: { type: 'string', example: 'Lightning' },
-        path: { type: 'string', example: 'Nihility' },
-        rarity: { type: 'number', example: 5 },
-        roles: { type: 'array', items: { type: 'string' }, example: ['DPS'] },
-        archetype: { type: 'array', items: { type: 'string' }, example: ['DoT'] },
-        labels: { type: 'array', items: { type: 'string' }, example: ['DoT', 'AoE'] },
-        prydwenLink: {
-          type: 'string',
-          example: 'https://www.prydwen.gg/star-rail/characters/kafka/',
-        },
-        guobaLink: { type: 'string', example: 'https://www.youtube.com/embed/xyz123' },
-        lightcones: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              id: { type: 'string', example: 'in-the-name-of-the-world' },
-              name: { type: 'string', example: 'In the Name of the World' },
-              rarity: { type: 'number', example: 5 },
-              path: { type: 'string', example: 'Nihility' },
-              note: { type: 'string', example: 'Best in slot vs. imaginary weak enemies' },
-            },
-          },
-        },
-      },
+      $ref: getSchemaPath(CreateCharacterDto),
     },
   })
   @ApiResponse({
@@ -183,12 +136,111 @@ export class CharactersController {
       },
     },
   })
-  async findOne(@Param('id') id: string): Promise<Character | { message: string }> {
+  async findOne(@Param('id') id: string): Promise<Character> {
     const character = await this.charactersService.findById(id)
     if (!character) {
-      return { message: 'Character not found' }
+      throw new HttpException('Character not found', HttpStatus.NOT_FOUND)
     }
     return character
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('bulk')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Bulk update nested character recommendations and team compositions (requires authentication)',
+    description:
+      'Use this endpoint to update many characters at once without rewriting full character payloads. It supports two admin workflows: adding IDs into teammate recommendation buckets, and replacing a specific slot inside matched team compositions. Start with `dryRun: true` to preview the result safely in Swagger before persisting changes.',
+  })
+  @ApiBody({
+    description: 'Bulk character operations with optional dry-run preview support',
+    type: BulkCharacterUpdateDto,
+    examples: {
+      addCyreneToBisTeammates: {
+        summary: 'Add Cyrene to the BiS amplifier list for multiple characters',
+        value: {
+          operations: [
+            {
+              type: 'upsert_teammate_recommendation',
+              characterIds: ['firefly', 'feixiao', 'boothill'],
+              sectionName: 'Amplifiers',
+              bucket: 'bis',
+              teammateIds: ['cyrene'],
+              mode: 'append_unique',
+            },
+          ],
+        },
+      },
+      replaceFinalBisSlot: {
+        summary: 'Replace the final BiS slot in matched teams with DHPT',
+        value: {
+          operations: [
+            {
+              type: 'replace_team_member',
+              characterIds: ['firefly', 'rappa', 'boothill'],
+              match: {
+                role: 'Main DPS',
+              },
+              variant: 'bis',
+              slotIndex: 3,
+              newCharacterId: 'dhpt',
+            },
+          ],
+          dryRun: true,
+        },
+      },
+      replaceSpecificSustainlessSlot: {
+        summary: 'Only replace a specific existing character in matched team slots',
+        value: {
+          operations: [
+            {
+              type: 'replace_team_member',
+              characterIds: ['firefly', 'boothill'],
+              match: {
+                nameContains: 'Sustainless',
+              },
+              variant: 'bis',
+              slotIndex: 3,
+              expectedCharacterId: 'ruan-mei',
+              newCharacterId: 'dhpt',
+            },
+          ],
+          dryRun: true,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Bulk update completed successfully',
+    type: BulkCharacterUpdateResponseDto,
+    examples: {
+      dryRunPreview: {
+        summary: 'Preview response',
+        value: {
+          dryRun: true,
+          operations: [
+            {
+              index: 0,
+              type: 'replace_team_member',
+              requestedCharacterIds: ['firefly', 'boothill', 'rappa'],
+              updatedCharacterIds: ['firefly', 'boothill'],
+              skippedCharacterIds: ['rappa'],
+              details: [
+                'Updated firefly composition "Main DPS Team" (bis) slot 3 -> dhpt',
+                'Updated boothill composition "Main DPS Team" (bis) slot 3 -> dhpt',
+                'Skipped rappa: character not found',
+              ],
+            },
+          ],
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid bulk update payload' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  bulkUpdateCharacters(@Body() bulkUpdate: BulkCharacterUpdateDto): Promise<BulkCharacterUpdateResponseDto> {
+    return this.charactersService.bulkUpdateCharacters(bulkUpdate)
   }
 
   @UseGuards(JwtAuthGuard)

--- a/packages/backend/src/characters/characters.service.ts
+++ b/packages/backend/src/characters/characters.service.ts
@@ -1,16 +1,35 @@
-import { Inject, Injectable, InternalServerErrorException, Logger } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, InternalServerErrorException, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository } from 'typeorm'
+import { In, Repository } from 'typeorm'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Cache } from 'cache-manager'
+import type { TeamComposition } from '../types/Character'
 import { Character } from '../types/Character'
 import { CharacterEntity } from '../entities/character.entity'
 import { LightconeEntity } from '../entities/lightcone.entity'
 import { CharacterLightconeEntity } from '../entities/character-lightcone.entity'
 import { allCharactersSeedData } from '../data/allCharactersData'
+import {
+  BulkCharacterOperationType,
+  BulkCharacterUpdateDto,
+  BulkListUpdateMode,
+  CharacterBulkOperationDto,
+  RecommendationBucket,
+  TeamCompositionMatchDto,
+  TeamVariantType,
+} from '../dto/character.dto'
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000
 const TEN_MINUTES_MS = 10 * 60 * 1000
+
+export interface BulkCharacterOperationResult {
+  index: number
+  type: BulkCharacterOperationType
+  requestedCharacterIds: string[]
+  updatedCharacterIds: string[]
+  skippedCharacterIds: string[]
+  details: string[]
+}
 
 @Injectable()
 export class CharactersService {
@@ -197,6 +216,76 @@ export class CharactersService {
     return this.entityToCharacter(entity)
   }
 
+  async bulkUpdateCharacters(
+    bulkUpdate: BulkCharacterUpdateDto,
+  ): Promise<{ dryRun: boolean; operations: BulkCharacterOperationResult[] }> {
+    const dryRun = bulkUpdate.dryRun ?? false
+    const cacheKeysToClear = new Set<string>()
+    const operationResults: BulkCharacterOperationResult[] = []
+
+    for (const [index, operation] of bulkUpdate.operations.entries()) {
+      this.validateBulkOperation(operation)
+
+      const requestedCharacterIds = [...new Set(operation.characterIds)]
+      const entities = await this.characterRepository.find({
+        where: { id: In(requestedCharacterIds) },
+        relations: ['lightconeRelations', 'lightconeRelations.lightcone'],
+      })
+      const entityMap = new Map(entities.map((entity) => [entity.id, entity]))
+
+      const result: BulkCharacterOperationResult = {
+        index,
+        type: operation.type,
+        requestedCharacterIds,
+        updatedCharacterIds: [],
+        skippedCharacterIds: [],
+        details: [],
+      }
+
+      for (const characterId of requestedCharacterIds) {
+        const entity = entityMap.get(characterId)
+        if (!entity) {
+          result.skippedCharacterIds.push(characterId)
+          result.details.push(`Skipped ${characterId}: character not found`)
+          continue
+        }
+
+        const changed =
+          operation.type === BulkCharacterOperationType.UPSERT_TEAMMATE_RECOMMENDATION
+            ? this.applyTeammateRecommendationBulkOperation(entity, operation, result.details)
+            : this.applyReplaceTeamMemberBulkOperation(entity, operation, result.details)
+
+        if (!changed) {
+          result.skippedCharacterIds.push(characterId)
+          continue
+        }
+
+        result.updatedCharacterIds.push(characterId)
+        if (!dryRun) {
+          await this.characterRepository.save(entity)
+          cacheKeysToClear.add(`character-${characterId}`)
+        }
+      }
+
+      operationResults.push(result)
+    }
+
+    if (!dryRun && cacheKeysToClear.size > 0) {
+      await Promise.all([
+        ...[...cacheKeysToClear].map((cacheKey) => this.cacheManager.del(cacheKey)),
+        this.cacheManager.del('all-characters'),
+      ])
+      this.logger.log(
+        `✅ Bulk updated ${cacheKeysToClear.size} characters and cleared related caches`,
+      )
+    }
+
+    return {
+      dryRun,
+      operations: operationResults,
+    }
+  }
+
   async deleteCharacter(id: string): Promise<boolean> {
     const result = await this.characterRepository.delete(id)
     if (result.affected && result.affected > 0) {
@@ -274,7 +363,8 @@ export class CharactersService {
         | 'Nihility'
         | 'Preservation'
         | 'Abundance'
-        | 'Remembrance',
+        | 'Remembrance'
+        | 'Elation',
       rarity: entity.rarity as 4 | 5,
       roles: entity.roles as ('DPS' | 'SUB_DPS' | 'SUPPORT' | 'SUSTAIN' | 'AMPLIFIER')[],
       archetype: entity.archetype as (
@@ -292,6 +382,7 @@ export class CharactersService {
         | 'Summon'
         | 'Debuff DPS'
         | 'DoT'
+        | 'Damage Distribution'
       )[],
       labels: entity.labels,
       prydwenLink: entity.prydwenLink || undefined,
@@ -313,10 +404,177 @@ export class CharactersService {
           | 'Nihility'
           | 'Preservation'
           | 'Abundance'
-          | 'Remembrance',
+          | 'Remembrance'
+          | 'Elation',
         note: relation.note || undefined,
       })),
     }
+  }
+
+  private validateBulkOperation(operation: CharacterBulkOperationDto): void {
+    if (operation.type === BulkCharacterOperationType.UPSERT_TEAMMATE_RECOMMENDATION) {
+      if (!operation.sectionName) {
+        throw new BadRequestException('sectionName is required for teammate recommendation updates')
+      }
+      if (!operation.bucket) {
+        throw new BadRequestException('bucket is required for teammate recommendation updates')
+      }
+      if (!operation.teammateIds?.length) {
+        throw new BadRequestException(
+          'teammateIds must contain at least one character for teammate recommendation updates',
+        )
+      }
+      return
+    }
+
+    if (!operation.variant) {
+      throw new BadRequestException('variant is required for team composition updates')
+    }
+    if (operation.slotIndex === undefined) {
+      throw new BadRequestException('slotIndex is required for team composition updates')
+    }
+    if (!operation.newCharacterId) {
+      throw new BadRequestException('newCharacterId is required for team composition updates')
+    }
+  }
+
+  private applyTeammateRecommendationBulkOperation(
+    entity: CharacterEntity,
+    operation: CharacterBulkOperationDto,
+    details: string[],
+  ): boolean {
+    const sectionName = operation.sectionName as string
+    const bucket = operation.bucket as RecommendationBucket
+    const teammateIds = [...new Set(operation.teammateIds as string[])]
+    const mode = operation.mode ?? BulkListUpdateMode.APPEND_UNIQUE
+
+    const recommendations = entity.teammateRecommendations
+      ? structuredClone(entity.teammateRecommendations)
+      : []
+
+    let section = recommendations.find((entry) => entry.name === sectionName)
+    if (!section) {
+      section = { name: sectionName, bis: [], generalist: [], f2p: [] }
+      recommendations.push(section)
+      details.push(`Created teammate section "${sectionName}" for ${entity.id}`)
+    }
+
+    const currentValues = section[bucket] ?? []
+    const nextValues =
+      mode === BulkListUpdateMode.REPLACE
+        ? teammateIds
+        : [...new Set([...currentValues, ...teammateIds])]
+
+    if (this.areStringArraysEqual(currentValues, nextValues)) {
+      details.push(`No teammate change needed for ${entity.id} (${sectionName}.${bucket})`)
+      return false
+    }
+
+    section[bucket] = nextValues
+    entity.teammateRecommendations = recommendations
+    details.push(
+      `Updated ${entity.id} teammate recommendations: ${sectionName}.${bucket} -> ${nextValues.join(', ')}`,
+    )
+    return true
+  }
+
+  private applyReplaceTeamMemberBulkOperation(
+    entity: CharacterEntity,
+    operation: CharacterBulkOperationDto,
+    details: string[],
+  ): boolean {
+    if (!entity.teamCompositions?.length) {
+      details.push(`Skipped ${entity.id}: no team compositions available`)
+      return false
+    }
+
+    const compositions = structuredClone(entity.teamCompositions)
+    const variantType = operation.variant as TeamVariantType
+    const slotIndex = operation.slotIndex as number
+    const newCharacterId = operation.newCharacterId as string
+    let updatedCount = 0
+
+    for (const composition of compositions) {
+      if (!this.teamCompositionMatches(composition, operation.match)) {
+        continue
+      }
+
+      const variant = variantType === TeamVariantType.BIS ? composition.bis : composition.f2p
+      if (!variant) {
+        continue
+      }
+
+      if (slotIndex >= variant.characters.length) {
+        details.push(
+          `Skipped ${entity.id} composition "${composition.name}": slot ${slotIndex} does not exist`,
+        )
+        continue
+      }
+
+      if (
+        operation.expectedCharacterId &&
+        variant.characters[slotIndex] !== operation.expectedCharacterId
+      ) {
+        details.push(
+          `Skipped ${entity.id} composition "${composition.name}": slot ${slotIndex} is ${variant.characters[slotIndex]}, expected ${operation.expectedCharacterId}`,
+        )
+        continue
+      }
+
+      if (variant.characters[slotIndex] === newCharacterId) {
+        continue
+      }
+
+      variant.characters[slotIndex] = newCharacterId
+      updatedCount++
+      details.push(
+        `Updated ${entity.id} composition "${composition.name}" (${variantType}) slot ${slotIndex} -> ${newCharacterId}`,
+      )
+    }
+
+    if (updatedCount === 0) {
+      if (operation.match?.name || operation.match?.nameContains || operation.match?.role) {
+        details.push(`No matching team composition changes applied for ${entity.id}`)
+      }
+      return false
+    }
+
+    entity.teamCompositions = compositions
+    return true
+  }
+
+  private teamCompositionMatches(
+    composition: TeamComposition,
+    match?: TeamCompositionMatchDto,
+  ): boolean {
+    if (!match) {
+      return true
+    }
+
+    if (match.name && composition.name !== match.name) {
+      return false
+    }
+
+    if (
+      match.nameContains &&
+      !composition.name.toLowerCase().includes(match.nameContains.toLowerCase())
+    ) {
+      return false
+    }
+
+    if (match.role && composition.role !== match.role) {
+      return false
+    }
+
+    return true
+  }
+
+  private areStringArraysEqual(left: string[], right: string[]): boolean {
+    if (left.length !== right.length) {
+      return false
+    }
+
+    return left.every((value, index) => value === right[index])
   }
 
   async seedCharacters(): Promise<{ message: string; count: number }> {

--- a/packages/backend/src/dto/character.dto.ts
+++ b/packages/backend/src/dto/character.dto.ts
@@ -1,7 +1,10 @@
 import {
+  ArrayNotEmpty,
   ArrayMinSize,
+  IsBoolean,
   IsArray,
   IsEnum,
+  IsInt,
   IsNumber,
   IsOptional,
   IsString,
@@ -41,6 +44,243 @@ export enum Role {
   SUB_DPS = 'SUB_DPS',
   SUPPORT = 'SUPPORT',
   SUSTAIN = 'SUSTAIN',
+  AMPLIFIER = 'AMPLIFIER',
+}
+
+export enum BulkCharacterOperationType {
+  UPSERT_TEAMMATE_RECOMMENDATION = 'upsert_teammate_recommendation',
+  REPLACE_TEAM_MEMBER = 'replace_team_member',
+}
+
+export enum RecommendationBucket {
+  BIS = 'bis',
+  GENERALIST = 'generalist',
+  F2P = 'f2p',
+}
+
+export enum BulkListUpdateMode {
+  APPEND_UNIQUE = 'append_unique',
+  REPLACE = 'replace',
+}
+
+export enum TeamVariantType {
+  BIS = 'bis',
+  F2P = 'f2p',
+}
+
+export class TeamCompositionMatchDto {
+  @ApiPropertyOptional({
+    description: 'Match a team composition by exact name',
+    example: 'Main DPS Team',
+  })
+  @IsOptional()
+  @IsString()
+  name?: string
+
+  @ApiPropertyOptional({
+    description: 'Match team compositions whose name contains this substring',
+    example: 'Sustainless',
+  })
+  @IsOptional()
+  @IsString()
+  nameContains?: string
+
+  @ApiPropertyOptional({
+    description: 'Match a team composition by role label',
+    example: 'Main DPS',
+  })
+  @IsOptional()
+  @IsString()
+  role?: string
+}
+
+export class CharacterBulkOperationDto {
+  @ApiProperty({
+    enum: BulkCharacterOperationType,
+    description:
+      'Bulk operation type. Use `upsert_teammate_recommendation` for teammate sections, or `replace_team_member` for team composition slots.',
+    example: BulkCharacterOperationType.UPSERT_TEAMMATE_RECOMMENDATION,
+  })
+  @IsEnum(BulkCharacterOperationType)
+  type: BulkCharacterOperationType
+
+  @ApiProperty({
+    description: 'Characters that should receive this operation',
+    type: [String],
+    example: ['firefly', 'feixiao', 'boothill'],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  characterIds: string[]
+
+  @ApiPropertyOptional({
+    description:
+      'Teammate recommendation section name to update. Required for `upsert_teammate_recommendation`.',
+    example: 'Amplifiers',
+  })
+  @IsOptional()
+  @IsString()
+  sectionName?: string
+
+  @ApiPropertyOptional({
+    enum: RecommendationBucket,
+    description:
+      'Recommendation bucket to edit inside the selected teammate section. Required for `upsert_teammate_recommendation`.',
+    example: RecommendationBucket.BIS,
+  })
+  @IsOptional()
+  @IsEnum(RecommendationBucket)
+  bucket?: RecommendationBucket
+
+  @ApiPropertyOptional({
+    description:
+      'Teammate IDs to add or replace in the target recommendation bucket. Required for `upsert_teammate_recommendation`.',
+    type: [String],
+    example: ['cyrene'],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  teammateIds?: string[]
+
+  @ApiPropertyOptional({
+    description:
+      'How to update the target recommendation bucket. `append_unique` keeps existing IDs and adds new ones only if missing. `replace` overwrites the full bucket.',
+    enum: BulkListUpdateMode,
+    default: BulkListUpdateMode.APPEND_UNIQUE,
+    example: BulkListUpdateMode.APPEND_UNIQUE,
+  })
+  @IsOptional()
+  @IsEnum(BulkListUpdateMode)
+  mode?: BulkListUpdateMode
+
+  @ApiPropertyOptional({
+    description:
+      'Filters that select which team compositions to update. Optional for `replace_team_member`; if omitted, all team compositions for each target character are considered.',
+    type: TeamCompositionMatchDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TeamCompositionMatchDto)
+  match?: TeamCompositionMatchDto
+
+  @ApiPropertyOptional({
+    description:
+      'Which variant inside the matched team composition should be edited. Required for `replace_team_member`.',
+    enum: TeamVariantType,
+    example: TeamVariantType.BIS,
+  })
+  @IsOptional()
+  @IsEnum(TeamVariantType)
+  variant?: TeamVariantType
+
+  @ApiPropertyOptional({
+    description:
+      '0-based team slot to replace inside the selected variant. Example: `3` targets the fourth/final team slot.',
+    minimum: 0,
+    example: 3,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  slotIndex?: number
+
+  @ApiPropertyOptional({
+    description:
+      'Optional safety check. Only replace the slot when it currently matches this character ID.',
+    example: 'ruan-mei',
+  })
+  @IsOptional()
+  @IsString()
+  expectedCharacterId?: string
+
+  @ApiPropertyOptional({
+    description:
+      'Character ID that will be written into the target slot. Required for `replace_team_member`.',
+    example: 'dhpt',
+  })
+  @IsOptional()
+  @IsString()
+  newCharacterId?: string
+}
+
+export class BulkCharacterUpdateDto {
+  @ApiProperty({
+    description: 'List of bulk operations to run sequentially',
+    type: [CharacterBulkOperationDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CharacterBulkOperationDto)
+  operations: CharacterBulkOperationDto[]
+
+  @ApiPropertyOptional({
+    description:
+      'Preview changes without persisting them. Useful to verify which characters and teams will be affected before applying the update.',
+    default: false,
+    example: true,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  dryRun?: boolean
+}
+
+export class BulkCharacterOperationResultDto {
+  @ApiProperty({ description: '0-based index of the operation in the request payload', example: 0 })
+  index: number
+
+  @ApiProperty({ enum: BulkCharacterOperationType, example: BulkCharacterOperationType.REPLACE_TEAM_MEMBER })
+  type: BulkCharacterOperationType
+
+  @ApiProperty({
+    description: 'Target character IDs requested for this operation',
+    type: [String],
+    example: ['firefly', 'boothill', 'rappa'],
+  })
+  requestedCharacterIds: string[]
+
+  @ApiProperty({
+    description: 'Character IDs that were actually modified',
+    type: [String],
+    example: ['firefly', 'boothill'],
+  })
+  updatedCharacterIds: string[]
+
+  @ApiProperty({
+    description: 'Character IDs that were skipped because nothing changed or the character was missing',
+    type: [String],
+    example: ['rappa'],
+  })
+  skippedCharacterIds: string[]
+
+  @ApiProperty({
+    description: 'Human-readable notes describing what happened for each target',
+    type: [String],
+    example: [
+      'Updated firefly composition "Main DPS Team" (bis) slot 3 -> dhpt',
+      'Skipped rappa: character not found',
+    ],
+  })
+  details: string[]
+}
+
+export class BulkCharacterUpdateResponseDto {
+  @ApiProperty({
+    description: 'Whether the request ran in preview mode without saving changes',
+    example: true,
+  })
+  dryRun: boolean
+
+  @ApiProperty({
+    description: 'Results for each requested bulk operation, in order',
+    type: [BulkCharacterOperationResultDto],
+  })
+  operations: BulkCharacterOperationResultDto[]
 }
 
 export class TeammateRecommendationDto {

--- a/packages/backend/src/lightcones/lightcones.controller.ts
+++ b/packages/backend/src/lightcones/lightcones.controller.ts
@@ -86,10 +86,10 @@ export class LightconesController {
       },
     },
   })
-  async findOne(@Param('id') id: string): Promise<Lightcone | { message: string }> {
+  async findOne(@Param('id') id: string): Promise<Lightcone> {
     const lightcone = await this.lightconesService.findById(id)
     if (!lightcone) {
-      return { message: 'Lightcone not found' }
+      throw new HttpException('Lightcone not found', HttpStatus.NOT_FOUND)
     }
     return lightcone
   }

--- a/packages/backend/src/lightcones/lightcones.service.ts
+++ b/packages/backend/src/lightcones/lightcones.service.ts
@@ -76,7 +76,8 @@ export class LightconesService {
         | 'Nihility'
         | 'Preservation'
         | 'Abundance'
-        | 'Remembrance',
+        | 'Remembrance'
+        | 'Elation',
     }
   }
 }

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -55,7 +55,7 @@ async function bootstrap() {
 
       return callback(new Error('Not allowed by CORS'), false)
     },
-    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
     credentials: true,
     maxAge: 86400, // Cache preflight response for 24 hours
   })
@@ -65,14 +65,11 @@ async function bootstrap() {
     .setTitle('HSR Team Builder API')
     .setDescription('API for Honkai Star Rail Team Builder application')
     .setVersion('1.0')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-      },
-      'access-token',
-    )
+    .addBearerAuth({
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    })
     .build()
   const document = SwaggerModule.createDocument(app, config)
   SwaggerModule.setup('swagger', app, document)

--- a/packages/backend/src/types/Character.ts
+++ b/packages/backend/src/types/Character.ts
@@ -43,6 +43,7 @@ export type Archetype =
   | 'Summon'
   | 'Debuff DPS'
   | 'DoT'
+  | 'Damage Distribution'
 
 // Flexible teammate section - you can name it whatever you want
 export interface TeammateSection {

--- a/packages/backend/src/types/CharacterEnums.ts
+++ b/packages/backend/src/types/CharacterEnums.ts
@@ -17,6 +17,7 @@ export const PATHS = [
   'Preservation',
   'Abundance',
   'Remembrance',
+  'Elation',
 ] as const
 
 export const RARITIES = [4, 5] as const
@@ -32,6 +33,7 @@ export const LIGHTCONE_PATHS = [
   'Preservation',
   'Abundance',
   'Remembrance',
+  'Elation',
 ] as const
 
 export const MAIN_ARCHETYPES = [

--- a/packages/backend/src/versions/versions.controller.ts
+++ b/packages/backend/src/versions/versions.controller.ts
@@ -70,10 +70,7 @@ export class VersionsController {
     const latestVersion = await this.versionsService.getLatestVersion()
 
     if (!latestVersion) {
-      return {
-        message: 'No versions available',
-        fallback: true,
-      }
+      throw new HttpException('No versions available', HttpStatus.NOT_FOUND)
     }
 
     return latestVersion
@@ -116,7 +113,7 @@ export class VersionsController {
       return found
     } catch (error) {
       if (error instanceof Error && error.message.includes('not found')) {
-        return { message: `Version ${version} not found` }
+        throw new HttpException(`Version ${version} not found`, HttpStatus.NOT_FOUND)
       }
       throw error
     }


### PR DESCRIPTION
## What changed
- fixed backend contract mismatches between Swagger, DTO validation, and runtime behavior
- added `PATCH /characters/bulk` for mass teammate recommendation and team composition updates
- improved Swagger docs for the bulk endpoint with clearer examples and an explicit response schema

## Why
The admin API was drifting from the actual backend behavior in a few places:
- `Elation` and `AMPLIFIER` were not consistently supported across backend types and DTO validation
- several endpoints documented `404` or `401` responses that were not actually returned at runtime
- bulk character maintenance required rewriting full character payloads, which makes repetitive updates error-prone

## Impact
- Swagger should now be easier to trust as the source of truth for character, lightcone, version, and auth admin flows
- admins can preview and apply mass updates for teammate recommendation buckets and team composition slots without rewriting entire character documents
- the new bulk route is designed for workflows like adding `cyrene` to BiS teammates or replacing a final BiS slot with `dhpt` across many characters

## Validation
- `npm run type-check` in `packages/backend`
- `npm run build` in `packages/backend`

## Notes
- the bulk endpoint supports `dryRun: true` so updates can be previewed safely before persisting changes
- the PR is opened as draft so the new admin flow can be reviewed before deployment