### PR TITLE
[codex] Fix filter UI and sustain grouping

### DIFF
--- a/packages/frontend/src/composables/useCharacterFilters.ts
+++ b/packages/frontend/src/composables/useCharacterFilters.ts
@@ -1,5 +1,6 @@
 import { ref, computed, type ComputedRef } from 'vue'
 import type { Character, Archetype } from '@hsr-team-builder/shared'
+import { canonicalizeArchetypes, canonicalizeArchetype } from '@/utils/archetypes'
 
 export function useCharacterFilters(characters: ComputedRef<Character[]>) {
   const selectedElements = ref<string[]>([])
@@ -25,8 +26,11 @@ export function useCharacterFilters(characters: ComputedRef<Character[]>) {
 
       const archetypeMatch =
         selectedArchetypes.value.length === 0 ||
-        selectedArchetypes.value.some((archetype) =>
-          character.archetype.includes(archetype as Archetype),
+        canonicalizeArchetypes(character.archetype).some((archetype) =>
+          selectedArchetypes.value.some(
+            (selectedArchetype) =>
+              archetype === canonicalizeArchetype(selectedArchetype as Archetype),
+          ),
         )
 
       return searchMatch && elementMatch && pathMatch && rarityMatch && archetypeMatch

--- a/packages/frontend/src/composables/useCharacterGrouping.ts
+++ b/packages/frontend/src/composables/useCharacterGrouping.ts
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import type { Character } from '@hsr-team-builder/shared'
+import { canonicalizeArchetypes, canonicalizeArchetype } from '@/utils/archetypes'
 
 export function useCharacterGrouping(
   filteredCharacters: { value: Character[] },
@@ -13,8 +14,11 @@ export function useCharacterGrouping(
       (char) => char.roles.includes('DPS') || char.roles.includes('SUB_DPS'),
     )
 
-    // Support Column - characters with role 'SUPPORT'
-    const supportCharacters = filtered.filter((char) => char.roles.includes('SUPPORT'))
+    // Support/Amplifier column excludes sustains so hybrid sustain units
+    // like shielders never appear in both support and sustain.
+    const supportCharacters = filtered.filter(
+      (char) => char.roles.includes('SUPPORT') && !char.roles.includes('SUSTAIN'),
+    )
 
     // Sustain Column - characters with role 'SUSTAIN'
     const sustainCharacters = filtered.filter((char) => char.roles.includes('SUSTAIN'))
@@ -24,11 +28,15 @@ export function useCharacterGrouping(
       const groups: { [key: string]: Character[] } = {}
 
       characters.forEach((char) => {
-        const archetypes = char.archetype || ['Other']
+        const archetypes = canonicalizeArchetypes(char.archetype || ['Other'])
 
         // If archetype filters are active, only show characters in those subcategories
         const relevantArchetypes = selectedArchetypes?.value.length
-          ? archetypes.filter((archetype) => selectedArchetypes.value.includes(archetype))
+          ? archetypes.filter((archetype) =>
+              selectedArchetypes.value.some(
+                (selectedArchetype) => canonicalizeArchetype(selectedArchetype) === archetype,
+              ),
+            )
           : archetypes
 
         // Add character to each of their relevant archetype groups

--- a/packages/frontend/src/composables/useHomeView.ts
+++ b/packages/frontend/src/composables/useHomeView.ts
@@ -73,9 +73,9 @@ export function useHomeView(characters: ComputedRef<Character[]>) {
     // If a character is selected, switch to their role's tab
     if (selectedCharacter.value) {
       const char = selectedCharacter.value
+      if (char.roles.includes('SUSTAIN') && hasCharactersInRole('sustain')) return 'sustain'
       if (char.roles.includes('DPS') && hasCharactersInRole('dps')) return 'dps'
       if (char.roles.includes('SUPPORT') && hasCharactersInRole('support')) return 'support'
-      if (char.roles.includes('SUSTAIN') && hasCharactersInRole('sustain')) return 'sustain'
     }
 
     // Default behavior: return first available tab

--- a/packages/frontend/src/utils/archetypes.ts
+++ b/packages/frontend/src/utils/archetypes.ts
@@ -1,0 +1,28 @@
+export const canonicalizeArchetype = (archetype: string) => {
+  const normalized = archetype.trim().toLowerCase()
+
+  switch (normalized) {
+    case 'shield':
+    case 'shields':
+    case 'shielder':
+    case 'shielders':
+      return 'Shielder'
+    case 'break dps':
+    case 'break-dps':
+      return 'Break-DPS'
+    case 'follow up':
+    case 'follow-up':
+      return 'Follow-up'
+    case 'ultimate based':
+    case 'ultimate-based':
+      return 'Ultimate-Based'
+    case 'hp scaling':
+    case 'hp-scaling':
+      return 'HP-Scaling'
+    default:
+      return archetype
+  }
+}
+
+export const canonicalizeArchetypes = (archetypes: string[]) =>
+  archetypes.map(canonicalizeArchetype)

--- a/packages/frontend/src/views/HomeView.vue
+++ b/packages/frontend/src/views/HomeView.vue
@@ -381,10 +381,10 @@ const getRecommendationTierForRoster = (characterId: string) =>
                     v-for="archetype in FILTER_OPTIONS.archetypes"
                     :key="archetype"
                     @click="toggleFilter(selectedArchetypes, archetype)"
-                    class="btn btn-sm fw-medium rounded-pill"
+                    class="btn btn-sm fw-medium rounded-pill filter-chip"
                     :class="
                       selectedArchetypes.includes(archetype)
-                        ? 'btn-primary text-dark'
+                        ? 'filter-chip-active'
                         : 'btn-outline-light'
                     "
                   >
@@ -1132,15 +1132,75 @@ body {
 
 .filter-card .btn-outline-secondary:hover,
 .filter-card .element-path-button.btn-outline-secondary:hover {
-  background-color: var(--bs-primary);
-  border-color: var(--bs-primary) !important;
-  color: #ffffff !important;
+  background-color: rgba(0, 212, 255, 0.12) !important;
+  border-color: rgba(0, 212, 255, 0.45) !important;
+  color: #d7f7ff !important;
 }
 
 .filter-card .btn-outline-light:hover {
-  background-color: var(--bs-primary);
-  border-color: var(--bs-primary);
-  color: #0b0b0b !important;
+  background-color: rgba(0, 212, 255, 0.12) !important;
+  border-color: rgba(0, 212, 255, 0.45) !important;
+  color: #eefbff !important;
+}
+
+.filter-card .btn-outline-primary.active,
+.filter-card .btn-outline-primary:hover,
+.filter-card .btn-outline-primary:active {
+  background-color: rgba(0, 212, 255, 0.24) !important;
+  border-color: rgba(78, 224, 255, 0.75) !important;
+  color: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.filter-card .btn-outline-secondary.active,
+.filter-card .element-path-button.active {
+  background-color: rgba(0, 212, 255, 0.24) !important;
+  border-color: rgba(78, 224, 255, 0.75) !important;
+  color: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.filter-card .btn-outline-secondary:focus,
+.filter-card .btn-outline-light:focus,
+.filter-card .element-path-button:focus,
+.filter-card .filter-chip:focus {
+  box-shadow: none !important;
+}
+
+.filter-card .btn-outline-secondary:focus-visible,
+.filter-card .btn-outline-light:focus-visible,
+.filter-card .element-path-button:focus-visible,
+.filter-card .filter-chip:focus-visible {
+  box-shadow: 0 0 0 0.18rem rgba(0, 212, 255, 0.18) !important;
+}
+
+.filter-card .filter-chip {
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.filter-card .filter-chip-active {
+  background-color: rgba(0, 212, 255, 0.24) !important;
+  border-color: rgba(78, 224, 255, 0.75) !important;
+  color: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.filter-card .filter-chip-active:hover,
+.filter-card .filter-chip-active:active {
+  background-color: rgba(0, 212, 255, 0.28) !important;
+  border-color: rgba(120, 233, 255, 0.9) !important;
+  color: #ffffff !important;
+  box-shadow: none !important;
+}
+
+.filter-card .filter-chip-active:focus-visible,
+.filter-card .btn-outline-primary.active:focus-visible,
+.filter-card .element-path-button.active:focus-visible {
+  box-shadow: 0 0 0 0.18rem rgba(0, 212, 255, 0.2) !important;
 }
 
 .prydwen-link {


### PR DESCRIPTION
## What changed
- normalize frontend archetype values so `shield` and `Shielder` resolve to the same filter/grouping value
- keep sustain-tagged characters out of the Amplifier column even when the backend also marks them as support
- make hybrid sustain characters default to the Sustain tab
- soften the filter button active/focus styling and fix the sticky blue focus state after deselection
- slightly brighten the final active filter state per review

## Why
The live production payload is currently inconsistent with the frontend assumptions:
- some archetypes arrive as `Shield` instead of `Shielder`
- Aventurine is returned with both `SUPPORT` and `SUSTAIN`, which caused him to appear in the Amplifier section

That mismatch broke the Shielder filter and caused sustain units to render in the wrong grid column.

## Impact
- shield-based filters now resolve correctly
- sustain shielders only show in the Sustain section of the grid
- filter buttons have a calmer selected state and deselect immediately without retaining the previous blue focus fill

## Validation
- `git diff --cached --check`
- `vue-tsc --build` was attempted earlier, but the repo already has unrelated existing type errors in `packages/frontend/src/views/HomeView.vue` around `prydwenLink`, `guobaLink`, and `lightcone.note`
