### PR TITLE
[codex] Fix dev version fallback and filter scroll

### DIFF
--- a/packages/frontend/src/composables/useVersionInfo.ts
+++ b/packages/frontend/src/composables/useVersionInfo.ts
@@ -25,8 +25,15 @@ export function useVersionInfo() {
   let versionRetryTimer: ReturnType<typeof setTimeout> | null = null
   let roadmapRetryTimer: ReturnType<typeof setTimeout> | null = null
 
-  // Get current app version from environment
-  const appVersion = computed(() => import.meta.env.VITE_APP_VERSION || 'v2.6.2')
+  const configuredAppVersion = import.meta.env.VITE_APP_VERSION?.trim()
+  const versionEndpoint = configuredAppVersion
+    ? `${API_BASE_URL}/versions/${configuredAppVersion}`
+    : `${API_BASE_URL}/versions/latest`
+
+  // Use the deployed app version when available, otherwise show the latest API version in dev.
+  const appVersion = computed(
+    () => currentVersionInfo.value?.version || configuredAppVersion || 'latest',
+  )
 
   const clearVersionRetryTimer = () => {
     if (versionRetryTimer) {
@@ -51,8 +58,7 @@ export function useVersionInfo() {
     error.value = null
 
     try {
-      // Try to fetch the current version from API
-      const response = await fetch(`${API_BASE_URL}/versions/${appVersion.value}`)
+      const response = await fetch(versionEndpoint)
 
       if (!response.ok) {
         throw new Error(`Failed to fetch version info: ${response.status}`)
@@ -67,7 +73,7 @@ export function useVersionInfo() {
 
       // Fallback content for current version
       currentVersionInfo.value = {
-        version: appVersion.value,
+        version: configuredAppVersion || 'latest',
         releaseDate: new Date().toISOString().split('T')[0],
         title: 'Responsive Character Details Fix',
         description: 'Improved mobile and desktop experience with better character detail layouts.',

--- a/packages/frontend/src/views/HomeView.vue
+++ b/packages/frontend/src/views/HomeView.vue
@@ -202,7 +202,7 @@ const getRecommendationTierForRoster = (characterId: string) =>
             </div>
 
             <!-- Filter Content (when no character selected) -->
-            <div v-if="!selectedCharacter" class="card-body">
+            <div v-if="!selectedCharacter" class="card-body filter-content">
               <!-- Search Bar -->
               <div class="mb-3 position-relative">
                 <div class="position-relative">
@@ -1476,6 +1476,13 @@ body {
 .card {
   scrollbar-width: thin;
   scrollbar-color: #00d4ff rgba(0, 0, 0, 0.2);
+}
+
+.filter-content {
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-bottom: 1rem;
 }
 
 /* Global Firefox Scrollbar */


### PR DESCRIPTION
## What changed
- make frontend version info fall back to `/versions/latest` when `VITE_APP_VERSION` is not injected
- keep explicit deployed version behavior when `VITE_APP_VERSION` is present
- add scrolling to the fixed-height filter panel so lower archetypes remain reachable

## Why
Local development was hardcoded to `v2.6.2`, which made the version modal misleading whenever the API had newer release records. The filter panel also clipped the lower archetype options because the card body did not scroll.

## Impact
- dev environments now show the latest backend version info by default
- production builds still use their configured version tag when injected at build time
- the filter panel now scrolls inside the fixed card height

## Validation
- `git diff --cached --check`
