### PR TITLE
[codex] add bulk character field updates

### DIFF
--- a/packages/backend/src/characters/characters.controller.ts
+++ b/packages/backend/src/characters/characters.controller.ts
@@ -207,32 +207,50 @@ export class CharactersController {
           dryRun: true,
         },
       },
+      addElationArchetype: {
+        summary: 'Add the Elation archetype to Elation DPS and amplifiers',
+        value: {
+          operations: [
+            {
+              type: 'update_character_fields',
+              characterIds: ['sparxie', 'silver-wolf-lv-999', 'elation-trailblazer'],
+              updates: {
+                archetype: ['Hypercarry', 'Elation'],
+              },
+            },
+            {
+              type: 'update_character_fields',
+              characterIds: ['yao-guang'],
+              updates: {
+                archetype: ['Buffer', 'Elation'],
+              },
+            },
+          ],
+          dryRun: true,
+        },
+      },
     },
   })
   @ApiResponse({
     status: 200,
     description: 'Bulk update completed successfully',
-    type: BulkCharacterUpdateResponseDto,
-    examples: {
-      dryRunPreview: {
-        summary: 'Preview response',
-        value: {
-          dryRun: true,
-          operations: [
-            {
-              index: 0,
-              type: 'replace_team_member',
-              requestedCharacterIds: ['firefly', 'boothill', 'rappa'],
-              updatedCharacterIds: ['firefly', 'boothill'],
-              skippedCharacterIds: ['rappa'],
-              details: [
-                'Updated firefly composition "Main DPS Team" (bis) slot 3 -> dhpt',
-                'Updated boothill composition "Main DPS Team" (bis) slot 3 -> dhpt',
-                'Skipped rappa: character not found',
-              ],
-            },
-          ],
-        },
+    schema: {
+      example: {
+        dryRun: true,
+        operations: [
+          {
+            index: 0,
+            type: 'replace_team_member',
+            requestedCharacterIds: ['firefly', 'boothill', 'rappa'],
+            updatedCharacterIds: ['firefly', 'boothill'],
+            skippedCharacterIds: ['rappa'],
+            details: [
+              'Updated firefly composition "Main DPS Team" (bis) slot 3 -> dhpt',
+              'Updated boothill composition "Main DPS Team" (bis) slot 3 -> dhpt',
+              'Skipped rappa: character not found',
+            ],
+          },
+        ],
       },
     },
   })

--- a/packages/backend/src/characters/characters.service.ts
+++ b/packages/backend/src/characters/characters.service.ts
@@ -13,6 +13,7 @@ import {
   BulkCharacterOperationType,
   BulkCharacterUpdateDto,
   BulkListUpdateMode,
+  CharacterFieldUpdatesDto,
   CharacterBulkOperationDto,
   RecommendationBucket,
   TeamCompositionMatchDto,
@@ -250,10 +251,7 @@ export class CharactersService {
           continue
         }
 
-        const changed =
-          operation.type === BulkCharacterOperationType.UPSERT_TEAMMATE_RECOMMENDATION
-            ? this.applyTeammateRecommendationBulkOperation(entity, operation, result.details)
-            : this.applyReplaceTeamMemberBulkOperation(entity, operation, result.details)
+        const changed = this.applyBulkOperation(entity, operation, result.details)
 
         if (!changed) {
           result.skippedCharacterIds.push(characterId)
@@ -382,6 +380,7 @@ export class CharactersService {
         | 'Summon'
         | 'Debuff DPS'
         | 'DoT'
+        | 'Elation'
         | 'Damage Distribution'
       )[],
       labels: entity.labels,
@@ -427,6 +426,13 @@ export class CharactersService {
       return
     }
 
+    if (operation.type === BulkCharacterOperationType.UPDATE_CHARACTER_FIELDS) {
+      if (!operation.updates || Object.keys(operation.updates).length === 0) {
+        throw new BadRequestException('updates is required for character field updates')
+      }
+      return
+    }
+
     if (!operation.variant) {
       throw new BadRequestException('variant is required for team composition updates')
     }
@@ -436,6 +442,68 @@ export class CharactersService {
     if (!operation.newCharacterId) {
       throw new BadRequestException('newCharacterId is required for team composition updates')
     }
+  }
+
+  private applyBulkOperation(
+    entity: CharacterEntity,
+    operation: CharacterBulkOperationDto,
+    details: string[],
+  ): boolean {
+    switch (operation.type) {
+      case BulkCharacterOperationType.UPSERT_TEAMMATE_RECOMMENDATION:
+        return this.applyTeammateRecommendationBulkOperation(entity, operation, details)
+      case BulkCharacterOperationType.UPDATE_CHARACTER_FIELDS:
+        return this.applyCharacterFieldUpdateBulkOperation(entity, operation, details)
+      case BulkCharacterOperationType.REPLACE_TEAM_MEMBER:
+        return this.applyReplaceTeamMemberBulkOperation(entity, operation, details)
+      default:
+        throw new BadRequestException(`Unsupported bulk operation type: ${operation.type}`)
+    }
+  }
+
+  private applyCharacterFieldUpdateBulkOperation(
+    entity: CharacterEntity,
+    operation: CharacterBulkOperationDto,
+    details: string[],
+  ): boolean {
+    const updates = operation.updates as CharacterFieldUpdatesDto
+    const changedFields: string[] = []
+
+    if (updates.roles && !this.areStringArraysEqual(entity.roles, updates.roles)) {
+      entity.roles = updates.roles
+      changedFields.push('roles')
+    }
+
+    if (updates.archetype && !this.areStringArraysEqual(entity.archetype, updates.archetype)) {
+      entity.archetype = updates.archetype
+      changedFields.push('archetype')
+    }
+
+    if (updates.labels && !this.areStringArraysEqual(entity.labels, updates.labels)) {
+      entity.labels = updates.labels
+      changedFields.push('labels')
+    }
+
+    if (
+      updates.prydwenLink !== undefined &&
+      (entity.prydwenLink ?? undefined) !== updates.prydwenLink
+    ) {
+      entity.prydwenLink = updates.prydwenLink
+      changedFields.push('prydwenLink')
+    }
+
+    if (updates.guobaLink !== undefined && (entity.guobaLink ?? undefined) !== updates.guobaLink) {
+      entity.guobaLink = updates.guobaLink
+      changedFields.push('guobaLink')
+    }
+
+    if (changedFields.length === 0) {
+      details.push(`No field change needed for ${entity.id}`)
+      return false
+    }
+
+    details.push(`Updated ${entity.id} fields: ${changedFields.join(', ')}`)
+    return true
   }
 
   private applyTeammateRecommendationBulkOperation(

--- a/packages/backend/src/dto/character.dto.ts
+++ b/packages/backend/src/dto/character.dto.ts
@@ -50,6 +50,7 @@ export enum Role {
 export enum BulkCharacterOperationType {
   UPSERT_TEAMMATE_RECOMMENDATION = 'upsert_teammate_recommendation',
   REPLACE_TEAM_MEMBER = 'replace_team_member',
+  UPDATE_CHARACTER_FIELDS = 'update_character_fields',
 }
 
 export enum RecommendationBucket {
@@ -92,6 +93,48 @@ export class TeamCompositionMatchDto {
   @IsOptional()
   @IsString()
   role?: string
+}
+
+export class CharacterFieldUpdatesDto {
+  @ApiPropertyOptional({ description: 'Replacement character roles', enum: Role, isArray: true })
+  @IsOptional()
+  @IsArray()
+  @IsEnum(Role, { each: true })
+  roles?: Role[]
+
+  @ApiPropertyOptional({
+    description: 'Replacement character archetypes',
+    example: ['Hypercarry', 'Elation'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  archetype?: string[]
+
+  @ApiPropertyOptional({
+    description: 'Replacement character descriptive labels',
+    example: ['AoE', 'Elation Damage'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  labels?: string[]
+
+  @ApiPropertyOptional({
+    description: 'Replacement Prydwen build guide link',
+    example: 'https://www.prydwen.gg/star-rail/characters/kafka/',
+  })
+  @IsOptional()
+  @IsString()
+  prydwenLink?: string
+
+  @ApiPropertyOptional({
+    description: 'Replacement Guoba video guide link',
+    example: 'https://www.youtube.com/embed/xyz123',
+  })
+  @IsOptional()
+  @IsString()
+  guobaLink?: string
 }
 
 export class CharacterBulkOperationDto {
@@ -205,6 +248,19 @@ export class CharacterBulkOperationDto {
   @IsOptional()
   @IsString()
   newCharacterId?: string
+
+  @ApiPropertyOptional({
+    description:
+      'Top-level character fields to replace. Required for `update_character_fields`. Supported fields: roles, archetype, labels, prydwenLink, guobaLink.',
+    type: CharacterFieldUpdatesDto,
+    example: {
+      archetype: ['Hypercarry', 'Elation'],
+    },
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CharacterFieldUpdatesDto)
+  updates?: CharacterFieldUpdatesDto
 }
 
 export class BulkCharacterUpdateDto {

--- a/packages/backend/src/types/Character.ts
+++ b/packages/backend/src/types/Character.ts
@@ -40,6 +40,7 @@ export type Archetype =
   | 'Counter'
   | 'Ultimate-Based'
   | 'Energy-Hungry'
+  | 'Elation'
   | 'Summon'
   | 'Debuff DPS'
   | 'DoT'

--- a/packages/frontend/src/components/TeamRecommendations.vue
+++ b/packages/frontend/src/components/TeamRecommendations.vue
@@ -127,7 +127,7 @@
                   </div>
                 </div>
               </div>
-              <p v-if="currentTeamComposition.bis.description" class="text-muted small mt-2">
+              <p v-if="currentTeamComposition.bis.description" class="team-description small mt-2">
                 {{ currentTeamComposition.bis.description }}
               </p>
             </div>
@@ -154,7 +154,7 @@
                   </div>
                 </div>
               </div>
-              <p v-if="currentTeamComposition.f2p.description" class="text-muted small mt-2">
+              <p v-if="currentTeamComposition.f2p.description" class="team-description small mt-2">
                 {{ currentTeamComposition.f2p.description }}
               </p>
             </div>
@@ -304,5 +304,10 @@ const getEntryStatus = (entry: ResolvedCharacterEntry) => {
   font-size: 0.72rem;
   line-height: 1.2;
   margin-top: 0.35rem;
+}
+
+.team-description {
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.45;
 }
 </style>

--- a/packages/frontend/src/constants/filterOptions.ts
+++ b/packages/frontend/src/constants/filterOptions.ts
@@ -19,6 +19,7 @@ export const FILTER_OPTIONS = {
     'Debuff DPS',
     'Debuffer',
     'DoT',
+    'Elation',
     'Follow-up',
     'Healer',
     'HP-Scaling',

--- a/packages/shared/src/Character.ts
+++ b/packages/shared/src/Character.ts
@@ -40,6 +40,7 @@ export type Archetype =
   | 'Counter'
   | 'Ultimate-Based'
   | 'Energy-Hungry'
+  | 'Elation'
   | 'Summon'
   | 'Debuff DPS'
   | 'DoT'

--- a/src/types/Character.ts
+++ b/src/types/Character.ts
@@ -36,6 +36,7 @@ export type Archetype =
   | 'Counter'
   | 'Ultimate-Based'
   | 'Energy-Hungry'
+  | 'Elation'
   | 'Summon'
   | 'Debuff DPS'
   | 'DoT'


### PR DESCRIPTION
## Summary

- Add `update_character_fields` support to the existing character bulk PATCH route for selected top-level fields.
- Add `Elation` as a typed/filterable archetype and include Swagger examples for Elation DPS/amplifier updates.
- Improve team composition description text color on the dark frontend theme.

## Deployment Notes

- Backend will deploy through Railway after approval/merge.
- Frontend deploy should be triggered after approval by tagging `v4.2.4`.

## Validation

- `npm run type-check`
- `npm run build:all`
- `git diff --check`