### PR TITLE
[codex] Document TestDino Playwright skill usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Notes
+
+This repository is a monorepo. Product code lives under `packages/*`; the Playwright automation framework lives under `tests/automation`.
+
+## Test Automation
+
+Before generating, reviewing, or changing Playwright tests, use the TestDino Playwright skill guidance:
+
+```bash
+npx skills add testdino-hq/playwright-skill
+```
+
+If the skill is already installed in the agent environment, use that local skill. For Codex environments this is commonly available as `playwright-skill`.
+
+Treat the skill as standards and implementation guidance, not as an application runtime dependency. Apply it for:
+
+- locator strategy
+- web-first assertions
+- waiting and flakiness prevention
+- Page Object Model boundaries
+- fixtures and typed API clients
+- API, E2E, integration, smoke, and visual guard tests
+- CI/debugging/reporting practices
+
+The automation package also exposes a repository-local discovery helper:
+
+```bash
+cd tests/automation
+npm run agent:install-skills
+```
+
+Read these files before changing tests:
+
+- `tests/automation/README.md`
+- `tests/automation/docs/PLAYWRIGHT_SKILLS_USAGE.md`
+- `tests/automation/docs/TEST_REVIEW_CHECKLIST.md`
+
+Run automation commands from `tests/automation` unless a command explicitly says otherwise.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ npm run build
 npm run lint
 ```
 
+## Test Automation
+
+Playwright automation lives in `tests/automation` and is intentionally separate from the frontend and backend packages. If you are using Codex or another coding agent from any working directory, start with [AGENTS.md](./AGENTS.md) and the automation README.
+
+This project expects TestDino Playwright skill guidance for test work:
+
+```sh
+npx skills add testdino-hq/playwright-skill
+```
+
+Use the skill as standards material for locators, web-first assertions, POMs, fixtures, API clients, CI, and flaky test prevention. It is not a production/runtime dependency.
+
+Common automation entry point:
+
+```sh
+cd tests/automation
+npm install
+npm run test:smoke
+```
+
 ## Usage
 
 1. **Browse Characters** - Characters are organized by their primary roles

--- a/tests/automation/README.md
+++ b/tests/automation/README.md
@@ -4,6 +4,26 @@ Standalone Playwright TypeScript automation framework for the HSR Team Builder m
 
 The framework validates the product from the outside: frontend smoke flows, backend API contracts, integration behavior, critical E2E paths, visual guards, and post-deploy checks. It intentionally lives under `tests/automation` instead of `packages/frontend` or `packages/backend`.
 
+## Agent and Skill Discovery
+
+If you are using Codex or another coding agent from the repo root, a parent folder, or another workspace location, first read the root `AGENTS.md` file. It points agents back to this automation package and its TestDino expectations.
+
+Before generating, reviewing, or modifying tests, use the TestDino Playwright skill guidance:
+
+```bash
+npx skills add testdino-hq/playwright-skill
+```
+
+If your agent environment already has the skill installed, use the local `playwright-skill` instead of reinstalling it. In this repo, TestDino guidance is standards material for test design and review; it is not a product runtime dependency.
+
+The local Playwright CLI helper can also initialize agent/browser tooling for this package:
+
+```bash
+npm run agent:install-skills
+```
+
+For the detailed policy, read `docs/PLAYWRIGHT_SKILLS_USAGE.md` and review modified tests against `docs/TEST_REVIEW_CHECKLIST.md`.
+
 ## Setup
 
 ```bash

--- a/tests/automation/docs/PLAYWRIGHT_SKILLS_USAGE.md
+++ b/tests/automation/docs/PLAYWRIGHT_SKILLS_USAGE.md
@@ -2,6 +2,16 @@
 
 This framework uses the TestDino Playwright skill guidance as standards material, not as a runtime dependency.
 
+This requirement applies no matter where an agent is launched from. If you start Codex or another tool outside `tests/automation`, read the root `AGENTS.md` file first, then this document.
+
+Install or discover the skill with the Skills CLI when it is missing:
+
+```bash
+npx skills add testdino-hq/playwright-skill
+```
+
+If the agent environment already has `playwright-skill` installed locally, use that copy instead of reinstalling.
+
 Apply it when generating, reviewing, or refactoring tests:
 
 - prefer user-facing locators and web-first assertions


### PR DESCRIPTION
## Summary

Documents how coding agents should discover and use the TestDino Playwright skill guidance for this monorepo's automation work.

## Changes

- Adds a root `AGENTS.md` entry point for Codex and other agents.
- Adds a root README pointer to `tests/automation` and the TestDino install command.
- Updates automation docs so agents launched from another directory still find the TestDino policy.
- Clarifies that TestDino guidance is standards material, not a runtime dependency.

## Validation

- `git diff --check`
- `git diff --cached --check`

No application tests were run because this is documentation-only.