### PR TITLE
[codex] Stop missing version metadata 404s

### DIFF
--- a/packages/backend/src/versions/versions.controller.ts
+++ b/packages/backend/src/versions/versions.controller.ts
@@ -105,15 +105,21 @@ export class VersionsController {
   @Get(':version')
   @ApiOperation({ summary: 'Get version by version string' })
   @ApiParam({ name: 'version', description: 'Version string (e.g., v2.6.2)' })
-  @ApiResponse({ status: 200, description: 'Version details' })
-  @ApiResponse({ status: 404, description: 'Version not found' })
+  @ApiResponse({ status: 200, description: 'Version details, falling back to latest if missing' })
+  @ApiResponse({ status: 404, description: 'No versions available' })
   async findOne(@Param('version') version: string) {
     try {
       const found = await this.versionsService.findOne(version)
       return found
     } catch (error) {
       if (error instanceof Error && error.message.includes('not found')) {
-        throw new HttpException(`Version ${version} not found`, HttpStatus.NOT_FOUND)
+        const latestVersion = await this.versionsService.getLatestVersion()
+
+        if (latestVersion) {
+          return latestVersion
+        }
+
+        throw new HttpException('No versions available', HttpStatus.NOT_FOUND)
       }
       throw error
     }

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -78,13 +78,13 @@
     <link
       rel="preload"
       as="style"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
       onload="this.onload=null;this.rel='stylesheet'"
     />
     <noscript>
       <link
         rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
       />
     </noscript>
   </head>

--- a/packages/frontend/src/composables/useVersionInfo.ts
+++ b/packages/frontend/src/composables/useVersionInfo.ts
@@ -20,26 +20,13 @@ export function useVersionInfo() {
   const isLoadingRoadmap = ref(false)
   const error = ref<string | null>(null)
   const roadmapError = ref<string | null>(null)
-  const RETRY_DELAY_MS = 10000
-
-  let roadmapRetryTimer: ReturnType<typeof setTimeout> | null = null
 
   const configuredAppVersion = import.meta.env.VITE_APP_VERSION?.trim()
-  const versionEndpoint = configuredAppVersion
-    ? `${API_BASE_URL}/versions/${configuredAppVersion}`
-    : `${API_BASE_URL}/versions/latest`
 
   // Use the deployed app version when available, otherwise show the latest API version in dev.
   const appVersion = computed(
     () => currentVersionInfo.value?.version || configuredAppVersion || 'latest',
   )
-
-  const clearRoadmapRetryTimer = () => {
-    if (roadmapRetryTimer) {
-      clearTimeout(roadmapRetryTimer)
-      roadmapRetryTimer = null
-    }
-  }
 
   const fetchVersionInfo = async () => {
     if (isLoading.value) {
@@ -50,14 +37,23 @@ export function useVersionInfo() {
     error.value = null
 
     try {
-      const response = await fetch(versionEndpoint)
+      const response = await fetch(
+        configuredAppVersion ? `${API_BASE_URL}/versions` : `${API_BASE_URL}/versions/latest`,
+      )
 
       if (!response.ok) {
         throw new Error(`Failed to fetch version info: ${response.status}`)
       }
 
       const data = await response.json()
-      currentVersionInfo.value = data
+      if (configuredAppVersion && Array.isArray(data)) {
+        currentVersionInfo.value =
+          data.find((versionInfo: VersionInfo) => versionInfo.version === configuredAppVersion) ||
+          data[0] ||
+          null
+      } else {
+        currentVersionInfo.value = data
+      }
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load version information'
       currentVersionInfo.value = null
@@ -84,7 +80,6 @@ export function useVersionInfo() {
 
       const data = await response.json()
       roadmapItems.value = Array.isArray(data) ? data : []
-      clearRoadmapRetryTimer()
     } catch (err) {
       roadmapError.value = err instanceof Error ? err.message : 'Failed to load roadmap'
       console.warn('Roadmap API unavailable, using fallback content')
@@ -93,13 +88,6 @@ export function useVersionInfo() {
       roadmapItems.value = [
         'Allow users to pick their owned characters, store locally, and recommend teams based on their roster',
       ]
-
-      if (!roadmapRetryTimer) {
-        roadmapRetryTimer = setTimeout(() => {
-          roadmapRetryTimer = null
-          void fetchRoadmap()
-        }, RETRY_DELAY_MS)
-      }
     } finally {
       isLoadingRoadmap.value = false
     }


### PR DESCRIPTION
## Summary

- Make public `GET /versions/:version` fall back to the latest version when a requested deploy tag is not in the versions table.
- Change frontend version metadata loading to call `/versions` for configured deploy versions and select a match client-side, falling back to the latest returned version.
- Remove the roadmap retry loop so a failed roadmap request does not keep polling every 10 seconds.
- Bump Font Awesome CDN from `6.0.0` to `6.7.2` to avoid the browser font metadata warning noise.

## Root Cause

Deploy tags such as `v4.3.2`, `v4.3.1`, and `v4.2.5` were injected into the frontend as `VITE_APP_VERSION`. The old frontend requested `/versions/<tag>`, but some deployed tags do not exist as rows in the production versions table, producing Railway 404 log volume.

## Validation

- `npm run build -w @hsr-team-builder/frontend`
- `npm run build -w @hsr-team-builder/backend`
- `git diff --check`
- Verified live API currently returns 404 for missing versions like `/versions/v4.3.2`, `/versions/v4.3.1`, and `/versions/v4.2.5`, while `/versions/v4.3.3` returns 200.