### PR TITLE
Log rejected CORS origins cleanly

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -41,19 +41,22 @@ async function bootstrap() {
     'http://localhost:4173',
     process.env.PRODUCTION_DOMAIN || 'https://hsr-team-builder.gilded.dev',
   ]
+  const isAllowedOrigin = (origin?: string) => !origin || allowedOrigins.includes(origin)
+
+  app.use((req, res, next) => {
+    const origin = req.headers.origin
+
+    if (origin && !isAllowedOrigin(origin)) {
+      logger.warn(`Rejected CORS origin ${origin} for ${req.method} ${req.originalUrl || req.url}`)
+      return res.status(403).json({ statusCode: 403, message: 'CORS origin not allowed' })
+    }
+
+    next()
+  })
 
   app.enableCors({
     origin: (origin, callback) => {
-      // Allow requests with no origin (mobile apps, etc.)
-      if (!origin) {
-        return callback(null, true)
-      }
-
-      if (allowedOrigins.includes(origin)) {
-        return callback(null, true)
-      }
-
-      return callback(new Error('Not allowed by CORS'), false)
+      return callback(null, isAllowedOrigin(origin))
     },
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
     credentials: true,


### PR DESCRIPTION
## Summary

- Keep blocking disallowed CORS origins.
- Return a clean 403 for rejected browser origins instead of throwing a Nest exception stack.
- Log the rejected Origin and request path so production logs show which origin was blocked.

## Validation

- `npm run build -w @hsr-team-builder/backend`