### PR TITLE
[codex] Fix free character roster ownership

### DIFF
--- a/packages/frontend/src/components/CharacterGrid.vue
+++ b/packages/frontend/src/components/CharacterGrid.vue
@@ -31,13 +31,13 @@
       "
     >
       <div class="character-state-badges">
-        <span v-if="isFreeCharacter(char.id)" class="state-badge free-badge">Free</span>
-        <span v-else-if="isRosterEditMode" class="state-badge edit-badge">
+        <span v-if="isRosterEditMode" class="state-badge edit-badge">
           {{ isCharacterDisabled(char.id) ? 'Not Owned' : 'Owned' }}
         </span>
         <span v-else-if="isCharacterDisabled(char.id)" class="state-badge unavailable-badge">
           Not Owned
         </span>
+        <span v-else-if="isFreeCharacter(char.id)" class="state-badge free-badge">Free</span>
       </div>
       <img
         :src="getCharacterAvatar(char.id)"

--- a/packages/frontend/src/composables/useRoster.ts
+++ b/packages/frontend/src/composables/useRoster.ts
@@ -10,6 +10,7 @@ import {
 
 interface StoredRosterConfig {
   disabledCharacterIds: string[]
+  importedOwnedCharacterIds?: string[]
 }
 
 export type ResolvedCharacterKind = 'owned' | 'free' | 'fallback' | 'unavailable' | 'custom'
@@ -44,6 +45,7 @@ export interface ResolvedTeamComposition {
 
 const savedDisabledCharacterIds = ref<Set<string>>(new Set())
 const stagedDisabledCharacterIds = ref<Set<string>>(new Set())
+const importedOwnedCharacterIds = ref<Set<string> | null>(null)
 const isRosterEditMode = ref(false)
 
 let hasLoadedRosterState = false
@@ -58,7 +60,16 @@ const sanitizeDisabledCharacterIds = (value: unknown): string[] => {
   return value
     .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
     .map((entry) => entry.trim())
-    .filter((entry) => !isFreeCharacterId(entry))
+}
+
+const sanitizeCharacterIds = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .map((entry) => entry.trim())
 }
 
 const loadStoredRosterConfig = (): StoredRosterConfig => {
@@ -75,19 +86,24 @@ const loadStoredRosterConfig = (): StoredRosterConfig => {
     const parsed = JSON.parse(rawValue) as Partial<StoredRosterConfig> | null
     return {
       disabledCharacterIds: sanitizeDisabledCharacterIds(parsed?.disabledCharacterIds),
+      importedOwnedCharacterIds: sanitizeCharacterIds(parsed?.importedOwnedCharacterIds),
     }
   } catch {
     return { disabledCharacterIds: [] }
   }
 }
 
-const persistRosterConfig = (disabledIds: Set<string>) => {
+const persistRosterConfig = (disabledIds: Set<string>, importedOwnedIds: Set<string> | null) => {
   if (typeof window === 'undefined') {
     return
   }
 
   const config: StoredRosterConfig = {
     disabledCharacterIds: [...disabledIds].sort(),
+  }
+
+  if (importedOwnedIds) {
+    config.importedOwnedCharacterIds = [...importedOwnedIds].sort()
   }
 
   window.localStorage.setItem(ROSTER_STORAGE_KEY, JSON.stringify(config))
@@ -101,6 +117,9 @@ const ensureRosterState = () => {
   const storedConfig = loadStoredRosterConfig()
   savedDisabledCharacterIds.value = cloneIdSet(storedConfig.disabledCharacterIds)
   stagedDisabledCharacterIds.value = cloneIdSet(storedConfig.disabledCharacterIds)
+  importedOwnedCharacterIds.value = storedConfig.importedOwnedCharacterIds
+    ? cloneIdSet(storedConfig.importedOwnedCharacterIds)
+    : null
   hasLoadedRosterState = true
 }
 
@@ -120,6 +139,16 @@ const areSetsEqual = (left: Set<string>, right: Set<string>) => {
 
   return true
 }
+
+const buildDisabledCharacterIdsFromImport = (
+  ownedCharacterIds: Set<string>,
+  characters: Character[],
+) =>
+  new Set(
+    characters
+      .map((character) => character.id)
+      .filter((characterId) => !ownedCharacterIds.has(characterId)),
+  )
 
 const buildResolvedEntry = (
   displayedId: string,
@@ -226,8 +255,8 @@ export function useRoster() {
   )
 
   const isCharacterDisabled = (characterId: string, useStaged = isRosterEditMode.value) => {
-    if (isFreeCharacterId(characterId)) {
-      return false
+    if (!useStaged && importedOwnedCharacterIds.value) {
+      return !importedOwnedCharacterIds.value.has(characterId)
     }
 
     const sourceIds = useStaged ? stagedDisabledCharacterIds.value : savedDisabledCharacterIds.value
@@ -235,10 +264,27 @@ export function useRoster() {
   }
 
   const isCharacterAvailable = (characterId: string, useStaged = isRosterEditMode.value) =>
-    isFreeCharacterId(characterId) || !isCharacterDisabled(characterId, useStaged)
+    !isCharacterDisabled(characterId, useStaged)
 
-  const enterRosterEditMode = () => {
-    stagedDisabledCharacterIds.value = cloneIdSet(savedDisabledCharacterIds.value)
+  const getDisabledCharacterIds = (
+    characters: Character[],
+    useStaged = isRosterEditMode.value,
+  ): string[] => {
+    if (useStaged) {
+      return [...stagedDisabledCharacterIds.value].sort()
+    }
+
+    if (importedOwnedCharacterIds.value) {
+      return [...buildDisabledCharacterIdsFromImport(importedOwnedCharacterIds.value, characters)].sort()
+    }
+
+    return [...savedDisabledCharacterIds.value].sort()
+  }
+
+  const enterRosterEditMode = (characters: Character[] = []) => {
+    stagedDisabledCharacterIds.value = importedOwnedCharacterIds.value
+      ? buildDisabledCharacterIdsFromImport(importedOwnedCharacterIds.value, characters)
+      : cloneIdSet(savedDisabledCharacterIds.value)
     isRosterEditMode.value = true
   }
 
@@ -249,11 +295,12 @@ export function useRoster() {
 
   const saveRosterEditMode = () => {
     savedDisabledCharacterIds.value = cloneIdSet(stagedDisabledCharacterIds.value)
-    persistRosterConfig(savedDisabledCharacterIds.value)
+    importedOwnedCharacterIds.value = null
+    persistRosterConfig(savedDisabledCharacterIds.value, importedOwnedCharacterIds.value)
     isRosterEditMode.value = false
   }
 
-  const selectAllNonFreeCharacters = () => {
+  const selectAllCharacters = () => {
     if (!isRosterEditMode.value) {
       return
     }
@@ -261,34 +308,27 @@ export function useRoster() {
     stagedDisabledCharacterIds.value = new Set()
   }
 
-  const hideAllNonFreeCharacters = (characters: Character[]) => {
+  const hideAllCharacters = (characters: Character[]) => {
     if (!isRosterEditMode.value) {
       return
     }
 
-    stagedDisabledCharacterIds.value = new Set(
-      characters
-        .map((character) => character.id)
-        .filter((characterId) => !isFreeCharacterId(characterId)),
-    )
+    stagedDisabledCharacterIds.value = new Set(characters.map((character) => character.id))
   }
 
   const applyImportedOwnedCharacterIds = (ownedCharacterIds: string[], characters: Character[]) => {
     const ownedIds = new Set(ownedCharacterIds)
-    const nextDisabledIds = new Set(
-      characters
-        .map((character) => character.id)
-        .filter((characterId) => !isFreeCharacterId(characterId) && !ownedIds.has(characterId)),
-    )
+    const nextDisabledIds = buildDisabledCharacterIdsFromImport(ownedIds, characters)
 
+    importedOwnedCharacterIds.value = ownedIds
     savedDisabledCharacterIds.value = nextDisabledIds
     stagedDisabledCharacterIds.value = cloneIdSet(nextDisabledIds)
-    persistRosterConfig(savedDisabledCharacterIds.value)
+    persistRosterConfig(savedDisabledCharacterIds.value, importedOwnedCharacterIds.value)
     isRosterEditMode.value = false
   }
 
   const toggleCharacterAvailability = (characterId: string) => {
-    if (!isRosterEditMode.value || isFreeCharacterId(characterId)) {
+    if (!isRosterEditMode.value) {
       return
     }
 
@@ -409,11 +449,12 @@ export function useRoster() {
     isRosterEditMode,
     isCharacterAvailable,
     isCharacterDisabled,
+    getDisabledCharacterIds,
     enterRosterEditMode,
     cancelRosterEditMode,
     saveRosterEditMode,
-    selectAllNonFreeCharacters,
-    hideAllNonFreeCharacters,
+    selectAllCharacters,
+    hideAllCharacters,
     applyImportedOwnedCharacterIds,
     toggleCharacterAvailability,
     getResolvedTeammateSections,

--- a/packages/frontend/src/utils/rosterImport.ts
+++ b/packages/frontend/src/utils/rosterImport.ts
@@ -1,5 +1,5 @@
 import type { Character } from '@hsr-team-builder/shared'
-import { getCharacterAvatarAssetIds } from '@/data/avatars'
+import { characterAvatarMap, getCharacterAvatarAssetIds, trailblazerAssetPairs } from '@/data/avatars'
 
 export interface ImportedRosterCharacter {
   archiveId: string
@@ -44,6 +44,20 @@ const isSafeArchiveId = (value: string) => /^\d{4}$/.test(value)
 
 const buildCharacterIdByArchiveId = (characters: Character[]) => {
   const characterIdByArchiveId = new Map<string, string>()
+
+  for (const [characterId, avatarId] of Object.entries(characterAvatarMap)) {
+    characterIdByArchiveId.set(avatarId, characterId)
+
+    const baseAvatarId = getBaseAvatarId(avatarId)
+    if (baseAvatarId) {
+      characterIdByArchiveId.set(baseAvatarId, characterId)
+    }
+  }
+
+  for (const [characterId, assetPair] of Object.entries(trailblazerAssetPairs)) {
+    characterIdByArchiveId.set(assetPair.caelus, characterId)
+    characterIdByArchiveId.set(assetPair.stelle, characterId)
+  }
 
   for (const character of characters) {
     for (const avatarId of getCharacterAvatarAssetIds(character.id)) {
@@ -96,21 +110,21 @@ export const parseReliquaryRosterArchive = (
     const characterId = characterIdByArchiveId.get(archiveId)
     const character = characterId ? characterById.get(characterId) : undefined
 
-    if (!character) {
+    if (!characterId) {
       unmatchedCharacters.push({ archiveId, archiveName })
       continue
     }
 
-    if (matchedCharacterIds.has(character.id)) {
+    if (matchedCharacterIds.has(characterId)) {
       continue
     }
 
-    matchedCharacterIds.add(character.id)
+    matchedCharacterIds.add(characterId)
     matchedCharacters.push({
       archiveId,
       archiveName,
-      characterId: character.id,
-      characterName: character.name,
+      characterId,
+      characterName: character?.name || archiveName || characterId,
     })
   }
 

--- a/packages/frontend/src/views/HomeView.vue
+++ b/packages/frontend/src/views/HomeView.vue
@@ -16,15 +16,15 @@ import type { Character, Lightcone } from '@hsr-team-builder/shared'
 // Use API-based characters
 const { characters, loadCharacters } = useCharactersApi()
 const {
-  disabledCharacterIds,
   hasStagedChanges,
   isRosterEditMode,
   isCharacterDisabled,
+  getDisabledCharacterIds,
   enterRosterEditMode,
   cancelRosterEditMode,
   saveRosterEditMode,
-  selectAllNonFreeCharacters,
-  hideAllNonFreeCharacters,
+  selectAllCharacters,
+  hideAllCharacters,
   applyImportedOwnedCharacterIds,
   toggleCharacterAvailability,
   isCharacterRecommended,
@@ -161,17 +161,16 @@ const applyRosterImport = (ownedCharacterIds: string[]) => {
   closeRosterImportModal()
 }
 
-const disabledCharacterCount = computed(() => disabledCharacterIds.value.length)
-const totalNonFreeCharacterCount = computed(
-  () => characters.value.filter((character) => !isFreeCharacterId(character.id)).length,
+const currentDisabledCharacterIds = computed(() => getDisabledCharacterIds(characters.value))
+const disabledCharacterCount = computed(() => currentDisabledCharacterIds.value.length)
+const totalCharacterCount = computed(() => characters.value.length)
+const areAllCharactersOwned = computed(
+  () => totalCharacterCount.value > 0 && disabledCharacterCount.value === 0,
 )
-const areAllNonFreeCharactersOwned = computed(
-  () => totalNonFreeCharacterCount.value > 0 && disabledCharacterCount.value === 0,
-)
-const areAllNonFreeCharactersHidden = computed(
+const areAllCharactersHidden = computed(
   () =>
-    totalNonFreeCharacterCount.value > 0 &&
-    disabledCharacterCount.value === totalNonFreeCharacterCount.value,
+    totalCharacterCount.value > 0 &&
+    disabledCharacterCount.value === totalCharacterCount.value,
 )
 
 const isRecommendedForRoster = (characterId: string) =>
@@ -843,7 +842,7 @@ const getRecommendationTierForRoster = (characterId: string) =>
           </div>
           <div class="d-flex align-items-center gap-2">
             <div class="legend-color" style="background-color: #17a2b8"></div>
-            <span class="text-white legend-text">Free / Locked</span>
+            <span class="text-white legend-text">Free</span>
           </div>
           <div class="d-flex align-items-center gap-2">
             <div class="legend-color" style="background-color: #ffc107"></div>
@@ -863,7 +862,7 @@ const getRecommendationTierForRoster = (characterId: string) =>
               <p class="text-secondary mb-0 small">
                 {{
                   isRosterEditMode
-                    ? 'Edit directly on the grid. Free characters stay locked and changes are only saved when you confirm.'
+                    ? 'Edit directly on the grid. Changes are only saved when you confirm.'
                     : 'Use Edit Roster to mark which characters you have, then save the grid to match your account.'
                 }}
               </p>
@@ -887,28 +886,28 @@ const getRecommendationTierForRoster = (characterId: string) =>
               <button
                 v-if="!isRosterEditMode"
                 class="btn btn-outline-info btn-sm fw-semibold rounded-pill"
-                @click="enterRosterEditMode()"
+                @click="enterRosterEditMode(characters)"
               >
                 Edit Roster
               </button>
               <template v-else>
                 <button
                   :class="
-                    areAllNonFreeCharactersOwned
+                    areAllCharactersOwned
                       ? 'btn btn-success btn-sm fw-semibold rounded-pill'
                       : 'btn btn-outline-success btn-sm fw-semibold rounded-pill'
                   "
-                  @click="selectAllNonFreeCharacters()"
+                  @click="selectAllCharacters()"
                 >
                   Select All
                 </button>
                 <button
                   :class="
-                    areAllNonFreeCharactersHidden
+                    areAllCharactersHidden
                       ? 'btn btn-danger btn-sm fw-semibold rounded-pill'
                       : 'btn btn-outline-danger btn-sm fw-semibold rounded-pill'
                   "
-                  @click="hideAllNonFreeCharacters(characters)"
+                  @click="hideAllCharacters(characters)"
                 >
                   Hide All
                 </button>


### PR DESCRIPTION
## Summary

Fixes roster ownership handling for free-obtainable characters and scanner JSON imports.

Free characters remain classified through `FREE_CHARACTER_IDS` so recommendation replacement rules can still label available free options correctly, but the frontend no longer forces them to be owned. Fresh accounts can mark characters such as Lynx or Xueyi as not owned, and scanner imports can do the same when those characters are absent from the JSON export.

The import flow now stores imported owned IDs and derives unavailable characters from the current catalog, so late-loaded API characters do not default to owned after an import. The scanner ID lookup also uses the full avatar map, so ownership is preserved even when the initial static fallback list is incomplete.

## Validation

- `npm run type-check -w @hsr-team-builder/frontend`
- `npm run build -w @hsr-team-builder/frontend`