### PR TITLE
Document version API release step

### DIFF
--- a/docs/CHARACTER_ADDITIONS.md
+++ b/docs/CHARACTER_ADDITIONS.md
@@ -25,6 +25,17 @@ For Mortenax Blade:
 
 The character and lightcone IDs used in Yaak must match these slugs exactly. Otherwise the API data will load but the UI will fall back to placeholder images.
 
+## Recommendation Research
+
+Before drafting Yaak bodies for a new character, research current character guidance from build/team sites such as Prydwen and Game8. Use those sources to shape:
+
+- teammate recommendation groups
+- best-in-slot, generalist, and free-to-play team suggestions
+- lightcone recommendations and notes
+- role, archetype, and label choices
+
+Do not invent teammate, lightcone, or team composition data from memory. Cross-check at least two sources when possible, and tell the user which sources informed the Yaak body. If reliable sources disagree or do not yet have complete guidance, leave uncertain recommendations empty or mark them for user confirmation instead of presenting them as final.
+
 ## Yaak API Order
 
 Create the lightcone before creating or updating the character, because character lightcone links reference an existing lightcone ID.

--- a/docs/UPLOAD_AND_DEPLOY_WORKFLOW.md
+++ b/docs/UPLOAD_AND_DEPLOY_WORKFLOW.md
@@ -53,7 +53,7 @@ Use this process for both fixes and new features.
 
 Frontend production deploys require a new version tag.
 
-After the PR is merged:
+After the PR is merged, create the tag from the merged `main` commit:
 
 ```bash
 git switch main
@@ -65,6 +65,54 @@ git push origin v4.3.6
 Pushing a `v*` tag triggers the production frontend deploy workflow.
 
 Backend production deploys are handled by Railway after backend changes reach the configured production branch. No frontend version tag is needed for backend-only changes unless the frontend also changed and needs a production deploy.
+
+## Version API Updates
+
+Update the backend Versions REST API for user-visible fixes and features so the app changelog/version metadata matches the release.
+
+The production API base URL is:
+
+```text
+https://api.hsr-team-builder.gilded.dev
+```
+
+Before creating or updating a version, ask the user to check whether the exact version already exists in Yaak:
+
+```text
+GET https://api.hsr-team-builder.gilded.dev/versions/v4.3.6
+```
+
+Important: `GET /versions/:version` can fall back to the latest version when the requested version is missing. Confirm the response body has the exact `version` value being released, such as `"version": "v4.3.6"`.
+
+If the version does not exist, prepare a Yaak-ready JSON body for the user to send with authenticated `POST /versions`.
+
+```text
+POST https://api.hsr-team-builder.gilded.dev/versions
+Authorization: Bearer <jwt>
+Content-Type: application/json
+```
+
+Example body:
+
+```json
+{
+  "version": "v4.3.6",
+  "title": "Roster Startup Fix",
+  "description": "Fixed first-load roster ownership state for users without an imported roster.",
+  "releaseDate": "2026-06-09",
+  "features": [],
+  "bugFixes": [
+    "Fixed fresh and legacy users seeing every character as not owned."
+  ],
+  "breakingChanges": [],
+  "knownIssues": [],
+  "roadmapItems": [],
+  "isActive": true,
+  "isPrerelease": false
+}
+```
+
+If the version exists and needs correction, prepare a Yaak-ready body for authenticated `PATCH /versions/:version` for partial changes or `PUT /versions/:version` to replace the full record.
 
 ## QA Deploys
 


### PR DESCRIPTION
## Summary

- Add the backend Versions REST API update step to the upload/deploy workflow.
- Document that future agents should prepare Yaak-ready version request details and JSON bodies for the user to send.
- Document the production API base URL, authenticated create/update endpoints, and the `GET /versions/:version` fallback caveat.
- Update the character addition guide so future Yaak character bodies are based on current recommendation research from sources like Prydwen and Game8, including teammates, teams, and lightcones.

## Validation

- Docs-only change; no application build run for this PR.